### PR TITLE
Add foundational components for Scala-native persistence engine

### DIFF
--- a/.github/agents/scala3-zio-agent.agent.md
+++ b/.github/agents/scala3-zio-agent.agent.md
@@ -353,6 +353,27 @@ object FooService:
 * Use `provideSomeLayer`/`provideLayer` to narrow environments instead of widening dependencies.
 * Combine schedules for retries/backoff, add timeouts or hedging when talking to external systems.
 
+## 10.9 ZIO Blocks Policy
+
+This repository allows selective use of `zio-blocks`, but agents should treat it as an additive toolkit rather than the default abstraction layer.
+
+Repository standards remain:
+
+* `zio.schema.Schema` for schema derivation and serialization boundaries
+* `zio.Chunk` / `NonEmptyChunk` for collection-heavy code
+* ZIO `Scope` / `ZLayer.scoped` for resource safety
+* `ZStream` for streaming pipelines
+
+Operational guidance:
+
+* Prefer current repo standards first.
+* Use `zio-blocks` only when the usage is local, additive, and clearly beneficial.
+* Use `TypeId` for stable type identity or registry metadata when it improves type-handler or migration internals.
+* Use `Context` for typed metadata propagation only when a plain case class or `ZEnvironment` would be clumsier.
+* Use `RingBuffer` only for benchmarked hot paths, buffering internals, or future ingestion/indexing experiments.
+* Do not replace `zio.schema.Schema`, `zio.Chunk`, ZIO `Scope`, or `ZStream` unless the task is an explicit migration.
+* Avoid introducing dual schema/chunk/scope ecosystems in the same feature unless explicitly requested.
+
 ---
 
 # 11. Output Rules for Agent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,30 @@ breaker(effect)
 ZIO.addFinalizer(fiber.interrupt *> cleanup)
 ```
 
+## 10.5 ZIO Blocks Policy
+
+This repository may use selected libraries from `zio-blocks`, but they are **additive tools**, not replacements for the current core stack.
+
+Project defaults remain:
+
+* `zio.schema.Schema` for schema derivation and serialization boundaries
+* `zio.Chunk` / `NonEmptyChunk` for collection-heavy code
+* ZIO `Scope` / `ZLayer.scoped` for resource safety
+* `ZStream` for streaming pipelines
+
+Agents may use `zio-blocks` selectively:
+
+* `TypeId` for stable type identity or registry metadata when it improves type-handler or migration internals
+* `Context` for typed metadata propagation only when a plain case class or `ZEnvironment` would be clumsier
+* `RingBuffer` only for benchmarked hot paths, buffering internals, or future ingestion/indexing experiments
+
+Rules:
+
+* Prefer the repository's existing ZIO and `zio-schema` abstractions first.
+* Use `zio-blocks` only when the usage is local, additive, and clearly beneficial.
+* Do **not** replace `zio.schema.Schema`, `zio.Chunk`, ZIO `Scope`, or `ZStream` unless the task is an explicit migration.
+* Avoid introducing dual schema/chunk/scope ecosystems inside the same feature unless explicitly requested.
+
 ---
 
 # 11. Output Rules for Codex

--- a/README.md
+++ b/README.md
@@ -281,6 +281,12 @@ If you want protobuf snapshots instead of JSON, run the protobuf variant:
 sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalProtobufApp"
 ```
 
+For an explicit v1-to-v2 NativeLocal snapshot migration example, run:
+
+```bash
+sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalVersioningApp"
+```
+
 For setup, HOCON loading, and snapshot semantics, see [`docs/native-local-guide.md`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
 
 For tests, the NativeLocal testkit also exposes scoped temp layers through [`NativeLocalObjectStore.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala), including an STM-enabled variant.

--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.Tod
 
 That sample now demonstrates envelope-backed snapshots plus automatic v1-to-v2 upgrade on startup for a versioned todo model.
 
+For an event-sourced NativeLocal sample that keeps an append-only journal plus a derived snapshot in the same root, run:
+
+```bash
+sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalEventSourcingApp"
+```
+
+That sample maps the "pure decision + effectful persistence boundary" model onto NativeLocal by replaying journal entries into a projected todo snapshot and checkpointing after every accepted command.
+
 For setup, HOCON loading, and snapshot semantics, see [`docs/native-local-guide.md`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
 
 For tests, the NativeLocal testkit also exposes scoped temp layers through [`NativeLocalObjectStore.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala), including an STM-enabled variant.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ Main entry point: `io.github.riccardomerolla.zio.eclipsestore.examples.bookstore
 sbt bookstore/run
 ```
 
+Event-sourced NativeLocal variant:
+
+```bash
+sbt "bookstore/runMain io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.BookstoreEventSourcingServerApp"
+```
+
+That variant keeps an append-only bookstore journal plus a derived catalog snapshot in a NativeLocal root, while reusing the same HTTP routes and `BookRepository` interface.
+
 Default port: `8080`. Available routes:
 
 | Method & Path | Description |

--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.Tod
 
 It uses a schema-derived immutable root, stores all state in one snapshot file, and demonstrates `ObjectStore.modify` plus explicit `checkpoint` and `restart`.
 
+If you want protobuf snapshots instead of JSON, run the protobuf variant:
+
+```bash
+sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalProtobufApp"
+```
+
 For setup, HOCON loading, and snapshot semantics, see [`docs/native-local-guide.md`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
 
 For tests, the NativeLocal testkit also exposes scoped temp layers through [`NativeLocalObjectStore.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala), including an STM-enabled variant.
@@ -518,16 +524,25 @@ yield status
 ```scala
 import java.nio.file.Paths
 
-import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, NativeLocalSerde }
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
 
-val backend = BackendConfig.NativeLocal(Paths.get("./data/root.snapshot.json"))
+val jsonBackend =
+  BackendConfig.NativeLocal(Paths.get("./data/root.snapshot.json"))
+
+val protobufBackend =
+  BackendConfig.NativeLocal(
+    Paths.get("./data/root.snapshot.pb"),
+    NativeLocalSerde.Protobuf,
+  )
 
 val services =
-  ZLayer.succeed(backend) >>>
+  ZLayer.succeed(protobufBackend) >>>
     StorageBackend.rootServices(MyRoot.descriptor)
 ```
+
+With HOCON, set `eclipsestore.backend.nativeLocal.serde = "protobuf"` to switch the snapshot encoding from JSON to protobuf.
 
 For configuration loading and lifecycle semantics, see [`docs/native-local-guide.md`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ For an explicit v1-to-v2 NativeLocal snapshot migration example, run:
 sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalVersioningApp"
 ```
 
+That sample now demonstrates envelope-backed snapshots plus automatic v1-to-v2 upgrade on startup for a versioned todo model.
+
 For setup, HOCON loading, and snapshot semantics, see [`docs/native-local-guide.md`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
 
 For tests, the NativeLocal testkit also exposes scoped temp layers through [`NativeLocalObjectStore.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala), including an STM-enabled variant.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ It uses a schema-derived immutable root, stores all state in one snapshot file, 
 
 For setup, HOCON loading, and snapshot semantics, see [`docs/native-local-guide.md`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
 
+For tests, the NativeLocal testkit also exposes scoped temp layers through [`NativeLocalObjectStore.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala), including an STM-enabled variant.
+
 ### Bookstore Backend Demo
 
 The `BookstoreServer` example reimplements the backend portion of EclipseStore’s [Bookstore demo](https://github.com/eclipse-store/bookstore-demo) using:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A ZIO-based library for type-safe, efficient, and boilerplate-free access to [Ec
 - **Performance Tuning**: Configure channels, caches, compression, off-heap page store, encryption
 - **Lazy Loading & Eager Storing**: Lazy references/collections plus eager-field semantics via examples
 - **ZIO Config Integration**: Load `EclipseStoreConfig` from HOCON/resources via zio-config
+- **Backend Selection**: Use `BackendConfig` and `StorageBackend.rootServices(...)` to switch between EclipseStore-backed engines and `NativeLocal`
 - **Effect-Oriented**: All operations are ZIO effects for composability
 
 ## Schema Integration
@@ -152,23 +153,46 @@ libraryDependencies ++= Seq(
 )
 ```
 
-Or load configuration with zio-config (HOCON/resource file):
+Or load EclipseStore-native configuration with zio-config (HOCON/resource file):
 
 ```scala
 import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfigZIO
-import zio.ConfigProvider
 
 val layer =
   EclipseStoreConfigZIO
-    .fromResource("application.conf") // or fromFile(Paths.get("..."))
-    .map(_.toLayer)                    // provides EclipseStoreConfig
-    .orDie
+    .fromResourcePath // or fromFile(Paths.get("application.conf"))
 
 // application.conf example (partial)
 // eclipsestore {
-//   storage-target = "filesystem:/data/store"
-//   performance.channel-count = 8
-//   backup.directory = "/data/backup"
+//   storageTarget {
+//     fileSystem {
+//       path = "/data/store"
+//     }
+//   }
+//   performance {
+//     channelCount = 8
+//   }
+//   backupDirectory = "/data/backup"
+// }
+```
+
+For local-first root services, load `BackendConfig` instead and let `StorageBackend.rootServices(...)` choose the engine:
+
+```scala
+import java.nio.file.Paths
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, EclipseStoreConfigZIO }
+import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
+
+val backendLayer =
+  EclipseStoreConfigZIO.backendFromFile(Paths.get("application.conf"))
+
+// application.conf example (partial)
+// eclipsestore {
+//   backend {
+//     nativeLocal {
+//       snapshotPath = "./data/bookstore.snapshot.json"
+//     }
+//   }
 // }
 ```
 
@@ -233,13 +257,34 @@ We ported the original EclipseStore “getting started” and “embedded storag
 
 Run them with `sbt "runMain full.qualified.ClassName"`.
 
+### Benchmarks
+
+NativeLocal performance baselines live in the dedicated `bench` project and use JMH.
+
+```bash
+sbt "bench/Jmh/run .*NativeLocalBenchmark.*"
+```
+
+### NativeLocal Todo Sample
+
+For a minimal local-first sample, run the NativeLocal todo app:
+
+```bash
+sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalApp"
+```
+
+It uses a schema-derived immutable root, stores all state in one snapshot file, and demonstrates `ObjectStore.modify` plus explicit `checkpoint` and `restart`.
+
+For setup, HOCON loading, and snapshot semantics, see [`docs/native-local-guide.md`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
+
 ### Bookstore Backend Demo
 
 The `BookstoreServer` example reimplements the backend portion of EclipseStore’s [Bookstore demo](https://github.com/eclipse-store/bookstore-demo) using:
 
 - `zio-eclipsestore` for persistence and typed roots
 - Schema-driven handler registration via `RootDescriptor.fromSchema`
-- `TypedStore` for schema-aware repository operations
+- `BackendConfig` and `StorageBackend.rootServices(...)` for backend selection
+- `ObjectStore[BookstoreRoot]` for repository operations
 - `zio-http` for the REST API
 - `zio-json` codecs for request/response bodies
 
@@ -259,7 +304,7 @@ Default port: `8080`. Available routes:
 | `PUT /books/{id}` | Update mutable fields (`UpdateBookRequest`) |
 | `DELETE /books/{id}` | Remove a book and persist the root |
 
-All write operations automatically persist the `BookstoreRoot` and you can trigger checkpoints/backups via `EclipseStoreService` if desired.
+All write operations automatically persist the `BookstoreRoot`, and the same server wiring can run on `FileSystem` or `NativeLocal` by changing the `BackendConfig`.
 
 ### Chat Models Schema Demo
 
@@ -463,6 +508,26 @@ for
   status <- EclipseStoreService.status
 yield status
 ```
+
+### BackendConfig and NativeLocal
+
+`BackendConfig` is the layer-facing backend selector. It covers the EclipseStore-backed targets and `NativeLocal`, which is a schema-driven whole-root snapshot engine for single-process local-first workloads.
+
+```scala
+import java.nio.file.Paths
+
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
+
+val backend = BackendConfig.NativeLocal(Paths.get("./data/root.snapshot.json"))
+
+val services =
+  ZLayer.succeed(backend) >>>
+    StorageBackend.rootServices(MyRoot.descriptor)
+```
+
+For configuration loading and lifecycle semantics, see [`docs/native-local-guide.md`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
 
 #### Backup targets
 

--- a/bench/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/bench/NativeLocalBenchmark.scala
+++ b/bench/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/bench/NativeLocalBenchmark.scala
@@ -1,0 +1,204 @@
+package io.github.riccardomerolla.zio.eclipsestore.bench
+
+import java.nio.file.{ Files, Path }
+import java.util.concurrent.TimeUnit
+
+import scala.compiletime.uninitialized
+import scala.jdk.CollectionConverters.*
+
+import org.openjdk.jmh.annotations.{ Scope as JmhScope, * }
+
+import zio.*
+import zio.schema.{ DeriveSchema, Schema }
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.{ NativeLocal, ObjectStore, StorageOps }
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.AverageTime))
+class NativeLocalBenchmark:
+
+  import NativeLocalBenchmark.*
+
+  @Benchmark
+  def startupFresh(state: StartupState): Int =
+    Unsafe.unsafe { implicit unsafe =>
+      state.runtime.unsafe
+        .run(startupProgram(state.freshSnapshotPath))
+        .getOrThrowFiberFailure()
+    }
+
+  @Benchmark
+  def startupFromSnapshot(state: StartupState): Int =
+    Unsafe.unsafe { implicit unsafe =>
+      state.runtime.unsafe
+        .run(startupProgram(state.seededSnapshotPath))
+        .getOrThrowFiberFailure()
+    }
+
+  @Benchmark
+  def modifyWarm(state: WarmState): Int =
+    Unsafe.unsafe { implicit unsafe =>
+      state.runtime.unsafe
+        .run(
+          ObjectStore.modify[BenchRoot, Int](root =>
+            ZIO.succeed {
+              val next = root.copy(values = root.values :+ root.values.size)
+              (next.values.size, next)
+            }
+          ).provideEnvironment(state.environment)
+        )
+        .getOrThrowFiberFailure()
+    }
+
+  @Benchmark
+  def checkpointWarm(state: WarmState): Int =
+    Unsafe.unsafe { implicit unsafe =>
+      state.runtime.unsafe
+        .run(
+          StorageOps
+            .checkpoint[BenchRoot]
+            .provideEnvironment(state.environment)
+            .as(state.snapshotSize())
+        )
+        .getOrThrowFiberFailure()
+    }
+
+  @Benchmark
+  def restoreFromSnapshot(state: RestoreState): Int =
+    Unsafe.unsafe { implicit unsafe =>
+      state.runtime.unsafe
+        .run(restoreProgram(state.baseSnapshotPath, state.importSnapshotPath))
+        .getOrThrowFiberFailure()
+    }
+
+object NativeLocalBenchmark:
+  final case class BenchRoot(values: Chunk[Int])
+
+  given Schema[BenchRoot] = DeriveSchema.gen[BenchRoot]
+  given Tag[BenchRoot]    = Tag.derived
+
+  private val descriptor =
+    RootDescriptor.fromSchema[BenchRoot]("native-local-bench-root", () => BenchRoot(Chunk.empty))
+
+  @State(JmhScope.Benchmark)
+  class StartupState:
+    val runtime: Runtime[Any] = Runtime.default
+
+    private var directory: Path = uninitialized
+
+    @Setup(Level.Trial)
+    def setup(): Unit =
+      directory = Files.createTempDirectory("native-local-startup-bench")
+      Unsafe.unsafe { implicit unsafe =>
+        runtime.unsafe.run(seedSnapshot(seededSnapshotPath, 1024)).getOrThrowFiberFailure()
+      }
+
+    @TearDown(Level.Trial)
+    def tearDown(): Unit =
+      deleteDirectory(directory)
+
+    def freshSnapshotPath: Path =
+      directory.resolve("fresh.snapshot.json")
+
+    def seededSnapshotPath: Path =
+      directory.resolve("seeded.snapshot.json")
+
+  @State(JmhScope.Benchmark)
+  class WarmState:
+    val runtime: Runtime[Any] = Runtime.default
+
+    private var directory0: Path = uninitialized
+    private var scope0: zio.Scope.Closeable = uninitialized
+    private var environment0: ZEnvironment[ObjectStore[BenchRoot] & StorageOps[BenchRoot]] = uninitialized
+
+    @Setup(Level.Trial)
+    def setup(): Unit =
+      directory0 = Files.createTempDirectory("native-local-warm-bench")
+      Unsafe.unsafe { implicit unsafe =>
+        runtime.unsafe.run(seedSnapshot(snapshotPath, 1024)).getOrThrowFiberFailure()
+        scope0 = runtime.unsafe.run(zio.Scope.make).getOrThrowFiberFailure()
+        environment0 = runtime.unsafe
+          .run(
+            NativeLocal
+              .live(snapshotPath, descriptor)
+              .build
+              .provideEnvironment(ZEnvironment(scope0))
+              .mapError(toRuntimeException)
+          )
+          .getOrThrowFiberFailure()
+      }
+
+    @TearDown(Level.Trial)
+    def tearDown(): Unit =
+      Unsafe.unsafe { implicit unsafe =>
+        runtime.unsafe.run(scope0.close(Exit.unit)).getOrThrowFiberFailure()
+      }
+      deleteDirectory(directory0)
+
+    def environment: ZEnvironment[ObjectStore[BenchRoot] & StorageOps[BenchRoot]] =
+      environment0
+
+    def snapshotPath: Path =
+      directory0.resolve("warm.snapshot.json")
+
+    def snapshotSize(): Int =
+      if Files.exists(snapshotPath) then Files.size(snapshotPath).toInt else 0
+
+  @State(JmhScope.Benchmark)
+  class RestoreState:
+    val runtime: Runtime[Any] = Runtime.default
+
+    private var directory: Path = uninitialized
+
+    @Setup(Level.Trial)
+    def setup(): Unit =
+      directory = Files.createTempDirectory("native-local-restore-bench")
+      Unsafe.unsafe { implicit unsafe =>
+        runtime.unsafe.run(seedSnapshot(importSnapshotPath, 2048)).getOrThrowFiberFailure()
+      }
+
+    @TearDown(Level.Trial)
+    def tearDown(): Unit =
+      deleteDirectory(directory)
+
+    def baseSnapshotPath: Path =
+      directory.resolve("base.snapshot.json")
+
+    def importSnapshotPath: Path =
+      directory.resolve("import.snapshot.json")
+
+  private def startupProgram(path: Path): ZIO[Any, RuntimeException, Int] =
+    ZIO.scoped {
+      for
+        env  <- NativeLocal.live(path, descriptor).build
+        root <- ObjectStore.load[BenchRoot].provideEnvironment(env)
+      yield root.values.size
+    }.mapError(toRuntimeException)
+
+  private def restoreProgram(basePath: Path, importPath: Path): ZIO[Any, RuntimeException, Int] =
+    ZIO.scoped {
+      for
+        env      <- NativeLocal.live(basePath, descriptor).build
+        _        <- StorageOps.importFrom[BenchRoot](importPath).provideEnvironment(env)
+        _        <- StorageOps.restart[BenchRoot].provideEnvironment(env)
+        restored <- ObjectStore.load[BenchRoot].provideEnvironment(env)
+      yield restored.values.size
+    }.mapError(toRuntimeException)
+
+  private def seedSnapshot(path: Path, size: Int): ZIO[Any, RuntimeException, Unit] =
+    ZIO.scoped {
+      for
+        env <- NativeLocal.live(path, descriptor).build
+        _   <- ObjectStore.replace(BenchRoot(Chunk.fromIterable(0 until size))).provideEnvironment(env)
+        _   <- StorageOps.checkpoint[BenchRoot].provideEnvironment(env)
+      yield ()
+    }.mapError(toRuntimeException)
+
+  private def toRuntimeException(error: EclipseStoreError): RuntimeException =
+    RuntimeException(error.toString)
+
+  private def deleteDirectory(path: Path): Unit =
+    if path != null && Files.exists(path) then
+      Files.walk(path).iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists)

--- a/bench/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/bench/NativeLocalBenchmarkSpec.scala
+++ b/bench/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/bench/NativeLocalBenchmarkSpec.scala
@@ -1,0 +1,53 @@
+package io.github.riccardomerolla.zio.eclipsestore.bench
+
+import zio.test.*
+
+object NativeLocalBenchmarkSpec extends ZIOSpecDefault:
+
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("NativeLocalBenchmark")(
+      test("startup benchmarks load the expected number of values") {
+        val benchmark = NativeLocalBenchmark()
+        val state     = NativeLocalBenchmark.StartupState()
+
+        try
+          state.setup()
+
+          val fresh  = benchmark.startupFresh(state)
+          val seeded = benchmark.startupFromSnapshot(state)
+
+          assertTrue(
+            fresh == 0,
+            seeded == 1024,
+          )
+        finally state.tearDown()
+      },
+      test("warm benchmarks mutate state and write snapshots") {
+        val benchmark = NativeLocalBenchmark()
+        val state     = NativeLocalBenchmark.WarmState()
+
+        try
+          state.setup()
+
+          val modified       = benchmark.modifyWarm(state)
+          val checkpointSize = benchmark.checkpointWarm(state)
+
+          assertTrue(
+            modified >= 1025,
+            checkpointSize > 0,
+          )
+        finally state.tearDown()
+      },
+      test("restore benchmark reloads imported snapshot contents") {
+        val benchmark = NativeLocalBenchmark()
+        val state     = NativeLocalBenchmark.RestoreState()
+
+        try
+          state.setup()
+
+          val restored = benchmark.restoreFromSnapshot(state)
+
+          assertTrue(restored == 2048)
+        finally state.tearDown()
+      },
+    )

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ ThisBuild / organizationName := "Riccardo Merolla"
 ThisBuild / organizationHomepage := Some(url("https://github.com/riccardomerolla"))
 
 lazy val zioVersion = "2.1.24"
+lazy val zioBlocksVersion = "0.0.33"
 lazy val zioSchemaVersion = "1.8.0"
 lazy val zioJsonVersion = "0.9.0"
 lazy val zioHttpVersion = "3.8.1"
@@ -56,6 +57,9 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio" % zioVersion,
       "dev.zio" %% "zio-streams" % zioVersion,
+      "dev.zio" %% "zio-blocks-typeid" % zioBlocksVersion,
+      "dev.zio" %% "zio-blocks-context" % zioBlocksVersion,
+      "dev.zio" %% "zio-blocks-ringbuffer" % zioBlocksVersion,
       "dev.zio" %% "zio-schema" % zioSchemaVersion,
       "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion,
       "dev.zio" %% "zio-schema-json" % zioSchemaVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val root = (project in file("."))
       "dev.zio" %% "zio-schema" % zioSchemaVersion,
       "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion,
       "dev.zio" %% "zio-schema-json" % zioSchemaVersion,
+      "dev.zio" %% "zio-schema-protobuf" % zioSchemaVersion,
       "dev.zio" %% "zio-json" % zioJsonVersion,
       "org.eclipse.store" % "storage-embedded" % eclipseStoreVersion,
       "org.eclipse.store" % "storage-embedded-configuration" % eclipseStoreVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -143,3 +143,15 @@ lazy val storageSqlite = (project in file("storage-sqlite"))
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
   )
   .dependsOn(root)
+
+lazy val bench = (project in file("bench"))
+  .enablePlugins(JmhPlugin)
+  .settings(
+    name := "zio-eclipsestore-bench",
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio" % zioVersion,
+      "dev.zio" %% "zio-schema" % zioSchemaVersion,
+      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion
+    )
+  )
+  .dependsOn(root)

--- a/build.sbt
+++ b/build.sbt
@@ -151,7 +151,10 @@ lazy val bench = (project in file("bench"))
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio" % zioVersion,
       "dev.zio" %% "zio-schema" % zioSchemaVersion,
-      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion
-    )
+      "dev.zio" %% "zio-schema-derivation" % zioSchemaVersion,
+      "dev.zio" %% "zio-test" % zioVersion % Test,
+      "dev.zio" %% "zio-test-sbt" % zioVersion % Test
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
   )
   .dependsOn(root)

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val root = (project in file("."))
       "dev.zio" %% "zio-config" % zioConfigVersion,
       "dev.zio" %% "zio-config-magnolia" % zioConfigVersion,
       "dev.zio" %% "zio-config-typesafe" % zioConfigVersion,
-      "dev.zio" %% "zio-test" % zioVersion % Test,
+      "dev.zio" %% "zio-test" % zioVersion,
       "dev.zio" %% "zio-test-sbt" % zioVersion % Test
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")

--- a/docs/native-local-guide.md
+++ b/docs/native-local-guide.md
@@ -98,7 +98,9 @@ The backend is optimized for determinism and simplicity, not multi-process coord
 
 ## Manual Versioned Snapshot Migration
 
-`NativeLocal` does not auto-upgrade incompatible snapshot schemas yet. The current pattern is explicit:
+`NativeLocal` now writes a small snapshot envelope around the schema payload. That envelope records the root id and a stable schema fingerprint, which makes explicit upgrade paths possible across restarts and across JSON or protobuf snapshots.
+
+For incompatible schema changes, the baseline pattern remains explicit:
 
 1. load the old snapshot with the old root schema
 2. migrate the decoded value into the new root model
@@ -110,7 +112,14 @@ The repository includes a concrete todo example for that flow:
 - [`TodoNativeLocalVersioningApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningApp.scala)
 - [`TodoNativeLocalVersioningSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningSpec.scala)
 
-That example models the schema version as an ADT, writes `TodoRootV1`, then migrates the snapshot in place to `TodoRootV2` with an explicit `MigrationPlan`. The v2 model removes the legacy `legacyCategory` field and adds a new `priority` field, after which the same snapshot file can be reopened through the v2 `NativeLocal` layer.
+That example models the schema version as an ADT, writes `TodoRootV1`, then upgrades the snapshot to `TodoRootV2`. The v2 model removes the legacy `legacyCategory` field and adds a new `priority` field.
+
+It demonstrates two upgrade modes:
+
+- manual migration through an explicit snapshot rewrite helper
+- automatic startup migration through a `NativeLocalSnapshotMigrationRegistry` entry backed by `DerivedMigrationPlan`
+
+`DerivedMigrationPlan` uses `zio-schema` to derive the safe structural part of the migration and still expects explicit defaults or overrides for semantic changes such as the new `priority` field.
 
 ## Optional STM Adapter
 

--- a/docs/native-local-guide.md
+++ b/docs/native-local-guide.md
@@ -35,12 +35,12 @@ The root type must have a `Schema[Root]`, and the root descriptor defines initia
 
 Relevant implementation points:
 
-- [`BackendConfig.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala)
-- [`StorageBackend.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala)
-- [`NativeLocal.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala)
-- [`NativeLocalSTM.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSTM.scala)
-- [`SnapshotCodec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/SnapshotCodec.scala)
-- [`NativeLocalObjectStore.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala)
+- [`BackendConfig.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala)
+- [`StorageBackend.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala)
+- [`NativeLocal.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala)
+- [`NativeLocalSTM.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSTM.scala)
+- [`SnapshotCodec.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/SnapshotCodec.scala)
+- [`NativeLocalObjectStore.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala)
 
 ## Config Loading
 
@@ -89,13 +89,13 @@ The backend is optimized for determinism and simplicity, not multi-process coord
 
 ## Optional STM Adapter
 
-If you want STM composition over the same NativeLocal root, use the additive [`NativeLocalSTM.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSTM.scala) service through `NativeLocal.liveWithSTM(...)`.
+If you want STM composition over the same NativeLocal root, use the additive [`NativeLocalSTM.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSTM.scala) service through `NativeLocal.liveWithSTM(...)`.
 
 The adapter commits STM updates into the shared root state and keeps `ObjectStore` and `StorageOps` semantics intact. It is intended as a stretch tool for local workflows, not as a replacement for the core backend contracts.
 
 ## Testkit Support
 
-For specs, the repository exposes scoped temporary NativeLocal layers through [`NativeLocalObjectStore.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala):
+For specs, the repository exposes scoped temporary NativeLocal layers through [`NativeLocalObjectStore.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala):
 
 - `tempLayer(...)` for `ObjectStore[Root] & StorageOps[Root]`
 - `tempLayerWithSTM(...)` for `ObjectStore[Root] & StorageOps[Root] & NativeLocalSTM[Root]`
@@ -104,15 +104,15 @@ These helpers create and clean up a temporary snapshot directory automatically, 
 
 Examples:
 
-- [`TestkitSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/TestkitSpec.scala)
-- [`NativeLocalSTMSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/NativeLocalSTMSpec.scala)
+- [`TestkitSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/TestkitSpec.scala)
+- [`NativeLocalSTMSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/NativeLocalSTMSpec.scala)
 
 ## Example
 
 The smallest runnable example is the todo app:
 
-- [`TodoNativeLocalApp.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala)
-- [`TodoNativeLocalAppSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala)
+- [`TodoNativeLocalApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala)
+- [`TodoNativeLocalAppSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala)
 
 Run it with:
 
@@ -135,7 +135,7 @@ Use `NativeLocal` when you want:
 - schema-driven persistence without EclipseStore runtime configuration
 - one-file snapshot export and restore semantics
 
-If the root is an immutable `Map`, you can also layer the additive [`LocalRepo.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/LocalRepo.scala) helpers on top of `ObjectStore` for basic CRUD without introducing a domain-specific repository immediately.
+If the root is an immutable `Map`, you can also layer the additive [`LocalRepo.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/LocalRepo.scala) helpers on top of `ObjectStore` for basic CRUD without introducing a domain-specific repository immediately.
 
 Use the EclipseStore-backed targets when you need:
 

--- a/docs/native-local-guide.md
+++ b/docs/native-local-guide.md
@@ -38,7 +38,9 @@ Relevant implementation points:
 - [`BackendConfig.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala)
 - [`StorageBackend.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala)
 - [`NativeLocal.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala)
+- [`NativeLocalSTM.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSTM.scala)
 - [`SnapshotCodec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/SnapshotCodec.scala)
+- [`NativeLocalObjectStore.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala)
 
 ## Config Loading
 
@@ -85,6 +87,26 @@ Current behavior:
 
 The backend is optimized for determinism and simplicity, not multi-process coordination.
 
+## Optional STM Adapter
+
+If you want STM composition over the same NativeLocal root, use the additive [`NativeLocalSTM.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSTM.scala) service through `NativeLocal.liveWithSTM(...)`.
+
+The adapter commits STM updates into the shared root state and keeps `ObjectStore` and `StorageOps` semantics intact. It is intended as a stretch tool for local workflows, not as a replacement for the core backend contracts.
+
+## Testkit Support
+
+For specs, the repository exposes scoped temporary NativeLocal layers through [`NativeLocalObjectStore.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala):
+
+- `tempLayer(...)` for `ObjectStore[Root] & StorageOps[Root]`
+- `tempLayerWithSTM(...)` for `ObjectStore[Root] & StorageOps[Root] & NativeLocalSTM[Root]`
+
+These helpers create and clean up a temporary snapshot directory automatically, which makes them suitable for property-style parity suites and restart tests.
+
+Examples:
+
+- [`TestkitSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/TestkitSpec.scala)
+- [`NativeLocalSTMSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/NativeLocalSTMSpec.scala)
+
 ## Example
 
 The smallest runnable example is the todo app:
@@ -112,6 +134,8 @@ Use `NativeLocal` when you want:
 - a lightweight local-first store for a small app or utility
 - schema-driven persistence without EclipseStore runtime configuration
 - one-file snapshot export and restore semantics
+
+If the root is an immutable `Map`, you can also layer the additive [`LocalRepo.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/LocalRepo.scala) helpers on top of `ObjectStore` for basic CRUD without introducing a domain-specific repository immediately.
 
 Use the EclipseStore-backed targets when you need:
 

--- a/docs/native-local-guide.md
+++ b/docs/native-local-guide.md
@@ -20,11 +20,14 @@ import java.nio.file.Paths
 
 import zio.*
 
-import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, NativeLocalSerde }
 import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
 
 val backend =
-  BackendConfig.NativeLocal(Paths.get("./data/app.snapshot.json"))
+  BackendConfig.NativeLocal(
+    Paths.get("./data/app.snapshot.pb"),
+    NativeLocalSerde.Protobuf,
+  )
 
 val services =
   ZLayer.succeed(backend) >>>
@@ -32,6 +35,11 @@ val services =
 ```
 
 The root type must have a `Schema[Root]`, and the root descriptor defines initialization and migration behavior.
+
+`NativeLocal` supports two snapshot codecs:
+
+- `NativeLocalSerde.Json` for text snapshots
+- `NativeLocalSerde.Protobuf` for binary protobuf snapshots
 
 Relevant implementation points:
 
@@ -61,13 +69,14 @@ Example config:
 eclipsestore {
   backend {
     nativeLocal {
-      snapshotPath = "./data/app.snapshot.json"
+      snapshotPath = "./data/app.snapshot.pb"
+      serde = "protobuf"
     }
   }
 }
 ```
 
-`EclipseStoreConfigZIO.backendFromResourcePath(...)` supports the same shape. If both `backend` and legacy `storageTarget` are present, `backend` wins.
+`EclipseStoreConfigZIO.backendFromResourcePath(...)` supports the same shape. If both `backend` and legacy `storageTarget` are present, `backend` wins. Accepted serde values are `json`, `proto`, and `protobuf`.
 
 ## Snapshot Semantics
 
@@ -109,22 +118,24 @@ Examples:
 
 ## Example
 
-The smallest runnable example is the todo app:
+The smallest runnable examples are the todo apps:
 
 - [`TodoNativeLocalApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala)
+- [`TodoNativeLocalProtobufApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala)
 - [`TodoNativeLocalAppSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala)
 
 Run it with:
 
 ```bash
 sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalApp"
+sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalProtobufApp"
 ```
 
-That sample demonstrates:
+Those samples demonstrate:
 
 - immutable root updates via `ObjectStore.modify`
 - explicit `checkpoint` plus `restart`
-- a single snapshot file on disk
+- JSON or protobuf snapshot files on disk
 - backend selection through `BackendConfig.NativeLocal`
 
 ## Choosing NativeLocal

--- a/docs/native-local-guide.md
+++ b/docs/native-local-guide.md
@@ -96,6 +96,22 @@ Current behavior:
 
 The backend is optimized for determinism and simplicity, not multi-process coordination.
 
+## Manual Versioned Snapshot Migration
+
+`NativeLocal` does not auto-upgrade incompatible snapshot schemas yet. The current pattern is explicit:
+
+1. load the old snapshot with the old root schema
+2. migrate the decoded value into the new root model
+3. save the migrated root back to the snapshot path
+4. boot the new `NativeLocal` layer against the migrated snapshot
+
+The repository includes a concrete todo example for that flow:
+
+- [`TodoNativeLocalVersioningApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningApp.scala)
+- [`TodoNativeLocalVersioningSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningSpec.scala)
+
+That example models the schema version as an ADT, writes `TodoRootV1`, then migrates the snapshot in place to `TodoRootV2` with an explicit `MigrationPlan`. The v2 model removes the legacy `legacyCategory` field and adds a new `priority` field, after which the same snapshot file can be reopened through the v2 `NativeLocal` layer.
+
 ## Optional STM Adapter
 
 If you want STM composition over the same NativeLocal root, use the additive [`NativeLocalSTM.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSTM.scala) service through `NativeLocal.liveWithSTM(...)`.
@@ -121,13 +137,16 @@ Examples:
 The smallest runnable examples are the todo apps:
 
 - [`TodoNativeLocalApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala)
+- [`TodoNativeLocalVersioningApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningApp.scala)
 - [`TodoNativeLocalProtobufApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala)
 - [`TodoNativeLocalAppSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala)
+- [`TodoNativeLocalVersioningSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningSpec.scala)
 
 Run it with:
 
 ```bash
 sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalApp"
+sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalVersioningApp"
 sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalProtobufApp"
 ```
 

--- a/docs/native-local-guide.md
+++ b/docs/native-local-guide.md
@@ -1,0 +1,120 @@
+# NativeLocal Guide
+
+`NativeLocal` is the smallest persistence backend in this repository. It keeps a single schema-derived root in memory and persists that root as one snapshot file on demand.
+
+It is intended for:
+
+- single-process applications
+- one logical root aggregate
+- local-first workflows
+- explicit checkpoint and restart control
+
+It is not a second top-level engine API. The public surface remains `ObjectStore[Root]`, `StorageOps[Root]`, `StorageBackend`, and `BackendConfig`.
+
+## Wiring
+
+Use `BackendConfig.NativeLocal` together with `StorageBackend.rootServices(...)`.
+
+```scala
+import java.nio.file.Paths
+
+import zio.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
+
+val backend =
+  BackendConfig.NativeLocal(Paths.get("./data/app.snapshot.json"))
+
+val services =
+  ZLayer.succeed(backend) >>>
+    StorageBackend.rootServices(MyRoot.descriptor)
+```
+
+The root type must have a `Schema[Root]`, and the root descriptor defines initialization and migration behavior.
+
+Relevant implementation points:
+
+- [`BackendConfig.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala)
+- [`StorageBackend.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala)
+- [`NativeLocal.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala)
+- [`SnapshotCodec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/SnapshotCodec.scala)
+
+## Config Loading
+
+If you want to select the backend from HOCON, load `BackendConfig` instead of the full `EclipseStoreConfig`.
+
+```scala
+import java.nio.file.Paths
+
+import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfigZIO
+
+val backendLayer =
+  EclipseStoreConfigZIO.backendFromFile(Paths.get("application.conf"))
+```
+
+Example config:
+
+```hocon
+eclipsestore {
+  backend {
+    nativeLocal {
+      snapshotPath = "./data/app.snapshot.json"
+    }
+  }
+}
+```
+
+`EclipseStoreConfigZIO.backendFromResourcePath(...)` supports the same shape. If both `backend` and legacy `storageTarget` are present, `backend` wins.
+
+## Snapshot Semantics
+
+`NativeLocal` persists the whole root. There is no partial object-graph storage contract in this backend.
+
+Current behavior:
+
+- startup: load the snapshot if present, otherwise use `RootDescriptor.initializer()`
+- decode failure: fail startup or restore with a typed `EclipseStoreError`
+- `ObjectStore.modify`: serialize immutable whole-root updates behind a gate
+- `StorageOps.checkpoint`: write the current root to the snapshot file
+- `StorageOps.restart`: reload from the snapshot file
+- `StorageOps.exportTo` and `backup`: copy snapshot bytes to another path
+- `StorageOps.importFrom` and `restoreFrom`: load another snapshot, replace the in-memory root, then persist it as the current snapshot
+- `StorageOps.shutdown`: checkpoint, then transition to `Stopped`
+- `StorageOps.housekeep`: currently the same as `checkpoint`
+
+The backend is optimized for determinism and simplicity, not multi-process coordination.
+
+## Example
+
+The smallest runnable example is the todo app:
+
+- [`TodoNativeLocalApp.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala)
+- [`TodoNativeLocalAppSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala)
+
+Run it with:
+
+```bash
+sbt "runMain io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal.TodoNativeLocalApp"
+```
+
+That sample demonstrates:
+
+- immutable root updates via `ObjectStore.modify`
+- explicit `checkpoint` plus `restart`
+- a single snapshot file on disk
+- backend selection through `BackendConfig.NativeLocal`
+
+## Choosing NativeLocal
+
+Use `NativeLocal` when you want:
+
+- a lightweight local-first store for a small app or utility
+- schema-driven persistence without EclipseStore runtime configuration
+- one-file snapshot export and restore semantics
+
+Use the EclipseStore-backed targets when you need:
+
+- larger mutable object graphs
+- richer storage-target configuration
+- existing EclipseStore operational behavior

--- a/docs/scala-native-engine-contract.md
+++ b/docs/scala-native-engine-contract.md
@@ -1,0 +1,54 @@
+# Scala-Native Engine Contract
+
+This document captures the baseline API contract for evolving `zio-eclipsestore` from a wrapper-oriented library into a Scala-native object-graph persistence engine.
+
+## Public API Boundary Rules
+
+The public Scala surface must follow these rules:
+
+- Public storage APIs return `ZIO[R, E, A]`, `IO[E, A]`, `UIO[A]`, or `ZStream[R, E, A]`.
+- Typed failures belong to the `PersistenceError` hierarchy or a narrower subsystem ADT that extends it.
+- Java-centric types do not leak into userland APIs:
+  - no `java.util.List`
+  - no raw `Object`
+  - no `null`-based API contracts
+  - no throws-based domain APIs
+- `Schema[A]` remains the userland serialization boundary.
+- `ZLayer` and `Scope` remain the wiring and lifecycle primitives.
+
+## Current Module Topology
+
+The repository currently implements these modules:
+
+- `zio-eclipsestore` (root): core service, config, schema integration, lifecycle APIs
+- `zio-eclipsestore-gigamap`: indexed map and vector-search support
+- `zio-eclipsestore-storage-sqlite`: SQLite storage adapter
+- `examples/bookstore`
+- `examples/gigamap-cli`
+- `examples/lazy-loading`
+
+This is the implemented topology in `build.sbt` today and is the starting point for the roadmap.
+
+## Target Module Topology
+
+The roadmap expands the current topology toward these subsystem boundaries:
+
+- `core`
+- `serializer`
+- `gigamap`
+- storage backends (`filesystem`, `sqlite`, `s3`, `azure`, `redis`, and related targets)
+- `observability`
+- `testkit`
+- `examples`
+- `docs`
+
+The current repository layout does not yet split all of these into separate sbt subprojects. This document defines the intended direction so later milestones can refine the build without changing the public contract ad hoc.
+
+## Version Compatibility Matrix
+
+| Line | EclipseStore | Scala | ZIO | Status |
+|---|---|---|---|---|
+| Current main branch | 4.0.1 | 3.5.2 | 2.1.24 | Active implementation baseline |
+| Scala-native engine roadmap | 4.x | 3.5+ | 2.1+ | Target contract for milestones `#35`-`#49` |
+
+Compatibility should be updated intentionally when one of these version anchors changes.

--- a/docs/scala-native-engine-samples.md
+++ b/docs/scala-native-engine-samples.md
@@ -83,6 +83,8 @@ The example demonstrates:
 
 - an explicit version ADT for the snapshot model
 - a v1-to-v2 migration that removes `legacyCategory` and adds `priority`
+- an envelope-backed snapshot that records the root id and schema fingerprint
+- automatic startup migration through `NativeLocalSnapshotMigrationRegistry`
 - reopening the same NativeLocal snapshot with the v2 root after migration
 - continuing to manage both migrated and newly created todos after the upgrade
 

--- a/docs/scala-native-engine-samples.md
+++ b/docs/scala-native-engine-samples.md
@@ -2,7 +2,7 @@
 
 This page is written in an `mdoc`-friendly style and documents the sample applications that exercise the Scala-native engine roadmap.
 
-For backend-level setup and runtime semantics, see the dedicated [`NativeLocal Guide`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
+For backend-level setup and runtime semantics, see the dedicated [`NativeLocal Guide`](native-local-guide.md).
 
 ## Bookstore v2
 
@@ -66,7 +66,7 @@ The sample demonstrates:
 - explicit persistence via `StorageOps.checkpoint` and `StorageOps.restart`
 - a single-file local-first workflow suitable for small applications
 
-For configuration loading and snapshot lifecycle details, see the [`NativeLocal Guide`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
+For configuration loading and snapshot lifecycle details, see the [`NativeLocal Guide`](native-local-guide.md).
 
 ## Semantic Search
 
@@ -96,19 +96,19 @@ The sample demonstrates:
 
 These samples and their specs cover the roadmap topics expected from the adoption track:
 
-- roots: [`ObjectStore`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/ObjectStore.scala)
-- lazy loading: [`Lazy`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/Lazy.scala)
-- ACID effects: [`Transaction`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/ObjectStore.scala)
-- storage targets: [`BackendConfig`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala)
-- migration: [`Migration`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/Migration.scala)
-- streaming: [`StreamingPersistence`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistence.scala)
-- lifecycle ops: [`StorageOps`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageOps.scala)
-- testkit: [`PersistenceSpec`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/PersistenceSpec.scala)
+- roots: [`ObjectStore`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/ObjectStore.scala)
+- lazy loading: [`Lazy`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/Lazy.scala)
+- ACID effects: [`Transaction`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/ObjectStore.scala)
+- storage targets: [`BackendConfig`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala)
+- migration: [`Migration`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/Migration.scala)
+- streaming: [`StreamingPersistence`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistence.scala)
+- lifecycle ops: [`StorageOps`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageOps.scala)
+- testkit: [`PersistenceSpec`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/PersistenceSpec.scala)
 
 ## Verification
 
 The executable checks for these examples live in:
 
-- [`BookstoreWorkflowSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflowSpec.scala)
-- [`TodoNativeLocalAppSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala)
-- [`SemanticSearchAppSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/examples/gigamap-cli/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/gigamap/SemanticSearchAppSpec.scala)
+- [`BookstoreWorkflowSpec.scala`](../examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflowSpec.scala)
+- [`TodoNativeLocalAppSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala)
+- [`SemanticSearchAppSpec.scala`](../examples/gigamap-cli/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/gigamap/SemanticSearchAppSpec.scala)

--- a/docs/scala-native-engine-samples.md
+++ b/docs/scala-native-engine-samples.md
@@ -75,6 +75,22 @@ The sample demonstrates:
 
 For configuration loading and snapshot lifecycle details, see the [`NativeLocal Guide`](native-local-guide.md).
 
+## NativeLocal Todo Versioning
+
+The versioning sample shows the current manual migration path for incompatible NativeLocal schema changes. It writes `TodoRootV1`, migrates the saved snapshot to `TodoRootV2`, and then continues with the upgraded model on the same snapshot path.
+
+The example demonstrates:
+
+- an explicit version ADT for the snapshot model
+- a v1-to-v2 migration that removes `legacyCategory` and adds `priority`
+- reopening the same NativeLocal snapshot with the v2 root after migration
+- continuing to manage both migrated and newly created todos after the upgrade
+
+See:
+
+- [`TodoNativeLocalVersioningApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningApp.scala)
+- [`TodoNativeLocalVersioningSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningSpec.scala)
+
 ## Semantic Search
 
 The vector-search sample uses `GigaMap` with a vector index and a secondary scalar index.

--- a/docs/scala-native-engine-samples.md
+++ b/docs/scala-native-engine-samples.md
@@ -42,6 +42,15 @@ val nativeLocalLayer =
   )
 ```
 
+There is also an event-sourced NativeLocal server variant for the bookstore HTTP example. It reuses the same `BookRoutes`, but its repository persists an append-only journal plus a derived snapshot in a NativeLocal root.
+
+See:
+
+- [`BookstoreEventSourcing.scala`](../examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/domain/BookstoreEventSourcing.scala)
+- [`BookstoreEventSourcingServer.scala`](../examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreEventSourcingServer.scala)
+- [`BookRepositoryEventSourcedSpec.scala`](../examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookRepositoryEventSourcedSpec.scala)
+- [`BookRoutesEventSourcedSpec.scala`](../examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookRoutesEventSourcedSpec.scala)
+
 ## NativeLocal Todo
 
 The todo sample is the smallest end-to-end example of the NativeLocal backend. It uses an immutable schema-derived root, `ObjectStore.modify`, and `StorageOps.restart` against a single snapshot file. There are JSON and protobuf variants.

--- a/docs/scala-native-engine-samples.md
+++ b/docs/scala-native-engine-samples.md
@@ -2,6 +2,8 @@
 
 This page is written in an `mdoc`-friendly style and documents the sample applications that exercise the Scala-native engine roadmap.
 
+For backend-level setup and runtime semantics, see the dedicated [`NativeLocal Guide`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
+
 ## Bookstore v2
 
 The bookstore sample uses typed roots, `ObjectStore`, `StorageOps`, and a migration plan for legacy data.
@@ -28,7 +30,43 @@ The sample demonstrates:
 - typed roots via `BookstoreRoot.descriptor`
 - ACID-style updates via `ObjectStore.transact`
 - operational lifecycle via `StorageOps.backup` and `StorageOps.restart`
+- backend selection via `BackendConfig` and `StorageBackend.rootServices(...)`
 - backwards-compatible schema evolution via `MigrationPlan`
+
+For a local-first runtime, the same sample can switch to `NativeLocal` without changing its service surface:
+
+```scala
+val nativeLocalLayer =
+  BookstoreWorkflow.layer(
+    BackendConfig.NativeLocal(Paths.get("bookstore-data/bookstore.snapshot.json"))
+  )
+```
+
+## NativeLocal Todo
+
+The todo sample is the smallest end-to-end example of the NativeLocal backend. It uses an immutable schema-derived root, `ObjectStore.modify`, and `StorageOps.restart` against a single snapshot file.
+
+```scala
+val layer =
+  TodoService.layer(Paths.get("todo-native-local.snapshot.json"))
+
+val program =
+  for
+    first    <- TodoService.add("write snapshot guide")
+    _        <- TodoService.add("verify restart semantics")
+    _        <- TodoService.complete(first.id)
+    reloaded <- TodoService.checkpointAndReload
+  yield reloaded.map(todo => (todo.title, todo.completed))
+```
+
+The sample demonstrates:
+
+- `BackendConfig.NativeLocal` as the layer-facing backend selector
+- immutable whole-root updates through `ObjectStore.modify`
+- explicit persistence via `StorageOps.checkpoint` and `StorageOps.restart`
+- a single-file local-first workflow suitable for small applications
+
+For configuration loading and snapshot lifecycle details, see the [`NativeLocal Guide`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/docs/native-local-guide.md).
 
 ## Semantic Search
 
@@ -72,4 +110,5 @@ These samples and their specs cover the roadmap topics expected from the adoptio
 The executable checks for these examples live in:
 
 - [`BookstoreWorkflowSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflowSpec.scala)
+- [`TodoNativeLocalAppSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala)
 - [`SemanticSearchAppSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/examples/gigamap-cli/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/gigamap/SemanticSearchAppSpec.scala)

--- a/docs/scala-native-engine-samples.md
+++ b/docs/scala-native-engine-samples.md
@@ -1,0 +1,75 @@
+# Scala-Native Engine Samples
+
+This page is written in an `mdoc`-friendly style and documents the sample applications that exercise the Scala-native engine roadmap.
+
+## Bookstore v2
+
+The bookstore sample uses typed roots, `ObjectStore`, `StorageOps`, and a migration plan for legacy data.
+
+```scala
+val workflowLayer =
+  BookstoreWorkflow.layer(BackendConfig.FileSystem(Paths.get("bookstore-data")))
+
+val program =
+  for
+    _        <- BookstoreWorkflow.createBook(
+                  CreateBookRequest("Zionomicon", "John de Goes", BigDecimal(49), Chunk("zio", "scala"))
+                )
+    _        <- BookstoreWorkflow.backup(Paths.get("bookstore-backup"))
+    catalog  <- BookstoreWorkflow.restartAndInventory
+    migrated <- BookstoreMigrations.migrate(
+                  LegacyBookRecord(BookId(UUID.randomUUID()), "Legacy title", "Legacy author", BigDecimal(19))
+                )
+  yield (catalog.sorted.map(_.title), migrated.shelf)
+```
+
+The sample demonstrates:
+
+- typed roots via `BookstoreRoot.descriptor`
+- ACID-style updates via `ObjectStore.transact`
+- operational lifecycle via `StorageOps.backup` and `StorageOps.restart`
+- backwards-compatible schema evolution via `MigrationPlan`
+
+## Semantic Search
+
+The vector-search sample uses `GigaMap` with a vector index and a secondary scalar index.
+
+```scala
+val documents = Chunk(
+  SemanticDocument("engine", "Scala-native engine", "architecture", "...", Chunk(0.99f, 0.02f, 0.01f)),
+  SemanticDocument("vectors", "Vector indexes", "search", "...", Chunk(0.97f, 0.03f, 0.01f))
+)
+
+val searchProgram =
+  for
+    _       <- SemanticSearchSample.indexAll(documents)
+    nearest <- SemanticSearchSample.nearestNeighbors(Chunk(1.0f, 0.0f, 0.0f), limit = 2)
+    topic   <- SemanticSearchSample.byTopic("search")
+  yield (nearest.map(_.value.id), topic.map(_.id))
+```
+
+The sample demonstrates:
+
+- `GigaMapVectorIndex` for semantic retrieval
+- `GigaMapIndex.single` for exact-match filtering
+- combined example coverage for search and operational docs
+
+## Engine Concepts Covered
+
+These samples and their specs cover the roadmap topics expected from the adoption track:
+
+- roots: [`ObjectStore`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/ObjectStore.scala)
+- lazy loading: [`Lazy`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/Lazy.scala)
+- ACID effects: [`Transaction`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/ObjectStore.scala)
+- storage targets: [`BackendConfig`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala)
+- migration: [`Migration`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/Migration.scala)
+- streaming: [`StreamingPersistence`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistence.scala)
+- lifecycle ops: [`StorageOps`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageOps.scala)
+- testkit: [`PersistenceSpec`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/PersistenceSpec.scala)
+
+## Verification
+
+The executable checks for these examples live in:
+
+- [`BookstoreWorkflowSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflowSpec.scala)
+- [`SemanticSearchAppSpec.scala`](/Users/riccardo/git/github/riccardomerolla/zio-eclipsestore/examples/gigamap-cli/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/gigamap/SemanticSearchAppSpec.scala)

--- a/docs/scala-native-engine-samples.md
+++ b/docs/scala-native-engine-samples.md
@@ -93,6 +93,23 @@ See:
 - [`TodoNativeLocalVersioningApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningApp.scala)
 - [`TodoNativeLocalVersioningSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningSpec.scala)
 
+## NativeLocal Todo Event Sourcing
+
+The event-sourcing sample shows how to map a pure command handler onto NativeLocal without introducing a separate event-store backend. The root stores both a projected snapshot and an append-only journal, and the service checkpoints after each accepted command so a fresh reopen sees the same durable journal.
+
+The example demonstrates:
+
+- a pure `decide` function that returns domain events from the current projection
+- a pure `replay` function that folds journal entries back into the snapshot
+- an event-sourced root that keeps `snapshot`, `journal`, and `nextSequence` together
+- `ObjectStore.modify` as the effect boundary that atomically updates the in-memory root
+- `StorageOps.checkpoint` as the persistence step that makes accepted commands durable
+
+See:
+
+- [`TodoNativeLocalEventSourcingApp.scala`](../src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalEventSourcingApp.scala)
+- [`TodoNativeLocalEventSourcingSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalEventSourcingSpec.scala)
+
 ## Semantic Search
 
 The vector-search sample uses `GigaMap` with a vector index and a secondary scalar index.
@@ -136,4 +153,5 @@ The executable checks for these examples live in:
 
 - [`BookstoreWorkflowSpec.scala`](../examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflowSpec.scala)
 - [`TodoNativeLocalAppSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala)
+- [`TodoNativeLocalEventSourcingSpec.scala`](../src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalEventSourcingSpec.scala)
 - [`SemanticSearchAppSpec.scala`](../examples/gigamap-cli/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/gigamap/SemanticSearchAppSpec.scala)

--- a/docs/scala-native-engine-samples.md
+++ b/docs/scala-native-engine-samples.md
@@ -44,11 +44,17 @@ val nativeLocalLayer =
 
 ## NativeLocal Todo
 
-The todo sample is the smallest end-to-end example of the NativeLocal backend. It uses an immutable schema-derived root, `ObjectStore.modify`, and `StorageOps.restart` against a single snapshot file.
+The todo sample is the smallest end-to-end example of the NativeLocal backend. It uses an immutable schema-derived root, `ObjectStore.modify`, and `StorageOps.restart` against a single snapshot file. There are JSON and protobuf variants.
 
 ```scala
-val layer =
+val jsonLayer =
   TodoService.layer(Paths.get("todo-native-local.snapshot.json"))
+
+val protobufLayer =
+  TodoService.layer(
+    Paths.get("todo-native-local.snapshot.pb"),
+    NativeLocalSerde.Protobuf,
+  )
 
 val program =
   for
@@ -62,6 +68,7 @@ val program =
 The sample demonstrates:
 
 - `BackendConfig.NativeLocal` as the layer-facing backend selector
+- optional protobuf snapshots through `NativeLocalSerde.Protobuf`
 - immutable whole-root updates through `ObjectStore.modify`
 - explicit persistence via `StorageOps.checkpoint` and `StorageOps.restart`
 - a single-file local-first workflow suitable for small applications

--- a/docs/schema-serializer.md
+++ b/docs/schema-serializer.md
@@ -1,0 +1,29 @@
+# SchemaSerializer
+
+`SchemaSerializer` is the public Scala-native serialization boundary for `zio-eclipsestore`.
+
+It keeps ZIO Schema as the only user-facing contract for:
+
+- encoding domain values
+- decoding stored payloads
+- deriving stable `TypeHandler[A]` registrations
+- enriching `EclipseStoreConfig` so handler wiring happens before the storage manager starts
+
+The intended usage pattern is:
+
+```scala
+val serializer = SchemaSerializerLive()
+
+for
+  config  <- serializer.register[MyValue](EclipseStoreConfig.make(path))
+  payload <- serializer.encode(myValue)
+  value   <- serializer.decode[MyValue](payload)
+yield (config, value)
+```
+
+Operational rules:
+
+- userland code should depend on `Schema[A]`, not Java reflection or raw EclipseStore handlers
+- `TypeHandler[A]` is the Scala wrapper for the underlying binary handler
+- handler registration is automatic through `SchemaSerializer.register`
+- `TypedStore.handlersFor` delegates to the same registration path so the repository has one schema-registration surface

--- a/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreEventSourcingServer.scala
+++ b/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreEventSourcingServer.scala
@@ -1,0 +1,36 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.bookstore
+
+import java.nio.file.Paths
+
+import zio.*
+import zio.http.Server
+
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain.BookstoreEventRoot
+import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.http.BookRoutes
+import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.service.BookRepository
+import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
+
+object BookstoreEventSourcingServer:
+  val defaultBackendConfig: BackendConfig =
+    BackendConfig.NativeLocal(Paths.get("bookstore-event-sourcing.snapshot.json"))
+
+  val repositoryLayer: ZLayer[Any, Nothing, BookRepository] =
+    ZLayer.succeed(defaultBackendConfig) >>>
+      StorageBackend
+        .rootServices(BookstoreEventRoot.descriptor)
+        .mapError(err => new RuntimeException(err.toString))
+        .orDie >>>
+      BookRepository.eventSourcedLive
+
+object BookstoreEventSourcingServerApp extends ZIOAppDefault:
+  private val serverLayer: ZLayer[Any, Nothing, Server] =
+    Server.defaultWithPort(8081).orDie
+
+  override def run: URIO[ZIOAppArgs & Scope, Any] =
+    Server
+      .serve(BookRoutes.routes)
+      .provide(
+        serverLayer,
+        BookstoreEventSourcingServer.repositoryLayer,
+      )

--- a/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreServer.scala
+++ b/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreServer.scala
@@ -1,34 +1,34 @@
 package io.github.riccardomerolla.zio.eclipsestore.examples.bookstore
 
+import java.nio.file.Paths
+
 import zio.*
 import zio.http.Server
 
-import java.nio.file.Paths
-
-import io.github.riccardomerolla.zio.eclipsestore.config.{ EclipseStoreConfig, StorageTarget }
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
 import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain.BookstoreRoot
 import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.http.BookRoutes
 import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.service.BookRepository
-import io.github.riccardomerolla.zio.eclipsestore.schema.TypedStore
-import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
 
 object BookstoreServer extends ZIOAppDefault:
 
   private val serverLayer: ZLayer[Any, Nothing, Server] =
     Server.defaultWithPort(8080).orDie
 
+  private val defaultBackendConfig: BackendConfig =
+    BackendConfig.FileSystem(Paths.get("bookstore-data"))
+
   private val repositoryLayer: ZLayer[Any, Nothing, BookRepository] =
-    (
-      ZLayer.succeed(
-        EclipseStoreConfig(
-          storageTarget = StorageTarget.FileSystem(Paths.get("bookstore-data")),
-          rootDescriptors = Chunk.single(BookstoreRoot.descriptor),
+    ZLayer.succeed(defaultBackendConfig) >>>
+      StorageBackend
+        .rootServices(
+          BookstoreRoot.descriptor,
+          _.copy(rootDescriptors = Chunk.single(BookstoreRoot.descriptor)),
         )
-      ) >>>
-        EclipseStoreService.live.mapError(err => new RuntimeException(err.toString)).orDie >>>
-        TypedStore.live >>>
-        BookRepository.live
-    )
+        .mapError(err => new RuntimeException(err.toString))
+        .orDie >>>
+      BookRepository.live
 
   override def run: URIO[ZIOAppArgs & Scope, Any] =
     Server

--- a/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflow.scala
+++ b/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflow.scala
@@ -1,0 +1,109 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.bookstore
+
+import java.nio.file.Path
+import java.util.UUID
+
+import zio.*
+import zio.json.ast.Json
+import zio.schema.Schema
+import zio.schema.derived
+
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain.*
+import io.github.riccardomerolla.zio.eclipsestore.schema.{ Migration, MigrationPlan }
+import io.github.riccardomerolla.zio.eclipsestore.service.{ ObjectStore, StorageBackend, StorageOps, Transaction }
+
+final case class BookstoreCatalog(books: Chunk[Book]):
+  def sorted: Chunk[Book] =
+    books.sortBy(_.title)
+
+trait BookstoreWorkflow:
+  def createBook(payload: CreateBookRequest): IO[EclipseStoreError, Book]
+  def inventory: IO[EclipseStoreError, BookstoreCatalog]
+  def backup(target: Path): IO[EclipseStoreError, Unit]
+  def restartAndInventory: IO[EclipseStoreError, BookstoreCatalog]
+
+final case class BookstoreWorkflowLive(
+  objectStore: ObjectStore[BookstoreRoot],
+  storageOps: StorageOps[BookstoreRoot],
+) extends BookstoreWorkflow:
+  override def createBook(payload: CreateBookRequest): IO[EclipseStoreError, Book] =
+    for
+      book <- objectStore.transact(
+                Transaction.effect { root =>
+                  ZIO.attempt {
+                    val book = Book(
+                      id = BookId(UUID.randomUUID()),
+                      title = payload.title,
+                      author = payload.author,
+                      price = payload.price,
+                      tags = payload.tags,
+                    )
+                    root.storage.put(book.id.value, book)
+                    book
+                  }.mapError(cause => EclipseStoreError.QueryError("Failed to create bookstore sample book", Some(cause)))
+                }
+              )
+      root <- objectStore.load
+      _    <- objectStore.storeSubgraph(root.storage)
+    yield book
+
+  override def inventory: IO[EclipseStoreError, BookstoreCatalog] =
+    objectStore.load.map(root => BookstoreCatalog(Chunk.fromIterable(root.storage.values().toArray(Array.empty[Book]))))
+
+  override def backup(target: Path): IO[EclipseStoreError, Unit] =
+    storageOps.backup(target).unit
+
+  override def restartAndInventory: IO[EclipseStoreError, BookstoreCatalog] =
+    storageOps.restart *> inventory
+
+object BookstoreWorkflow:
+  def createBook(payload: CreateBookRequest): ZIO[BookstoreWorkflow, EclipseStoreError, Book] =
+    ZIO.serviceWithZIO[BookstoreWorkflow](_.createBook(payload))
+
+  val inventory: ZIO[BookstoreWorkflow, EclipseStoreError, BookstoreCatalog] =
+    ZIO.serviceWithZIO[BookstoreWorkflow](_.inventory)
+
+  def backup(target: Path): ZIO[BookstoreWorkflow, EclipseStoreError, Unit] =
+    ZIO.serviceWithZIO[BookstoreWorkflow](_.backup(target))
+
+  val restartAndInventory: ZIO[BookstoreWorkflow, EclipseStoreError, BookstoreCatalog] =
+    ZIO.serviceWithZIO[BookstoreWorkflow](_.restartAndInventory)
+
+  def layer(backendConfig: BackendConfig): ZLayer[Any, EclipseStoreError, BookstoreWorkflow] =
+    ZLayer.make[BookstoreWorkflow](
+      ZLayer.succeed(backendConfig),
+      StorageBackend.service(_.copy(rootDescriptors = Chunk.single(BookstoreRoot.descriptor))),
+      ObjectStore.live(BookstoreRoot.descriptor),
+      StorageOps.live(BookstoreRoot.descriptor),
+      ZLayer.fromFunction(BookstoreWorkflowLive.apply),
+    )
+
+final case class LegacyBookRecord(
+  id: BookId,
+  title: String,
+  author: String,
+  price: BigDecimal,
+) derives Schema
+
+final case class BookRecordV2(
+  id: BookId,
+  title: String,
+  author: String,
+  price: BigDecimal,
+  tags: Chunk[String],
+  shelf: String,
+) derives Schema
+
+object BookstoreMigrations:
+  val legacyToV2: MigrationPlan[LegacyBookRecord, BookRecordV2] =
+    Migration
+      .define[LegacyBookRecord, BookRecordV2](
+        Migration.addField("tags", Json.Arr()),
+        Migration.addField("shelf", Json.Str("general")),
+      )
+      .plan
+
+  def migrate(record: LegacyBookRecord): IO[EclipseStoreError, BookRecordV2] =
+    legacyToV2.migrate(record)

--- a/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflow.scala
+++ b/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflow.scala
@@ -74,9 +74,10 @@ object BookstoreWorkflow:
   def layer(backendConfig: BackendConfig): ZLayer[Any, EclipseStoreError, BookstoreWorkflow] =
     ZLayer.make[BookstoreWorkflow](
       ZLayer.succeed(backendConfig),
-      StorageBackend.service(_.copy(rootDescriptors = Chunk.single(BookstoreRoot.descriptor))),
-      ObjectStore.live(BookstoreRoot.descriptor),
-      StorageOps.live(BookstoreRoot.descriptor),
+      StorageBackend.rootServices(
+        BookstoreRoot.descriptor,
+        _.copy(rootDescriptors = Chunk.single(BookstoreRoot.descriptor)),
+      ),
       ZLayer.fromFunction(BookstoreWorkflowLive.apply),
     )
 

--- a/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/domain/BookstoreEventSourcing.scala
+++ b/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/domain/BookstoreEventSourcing.scala
@@ -1,0 +1,155 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain
+
+import zio.*
+import zio.schema.Schema
+import zio.schema.derived
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+
+enum BookstoreCommand derives Schema:
+  case Create(book: Book)
+  case Update(id: BookId, payload: UpdateBookRequest)
+  case Delete(id: BookId)
+
+enum BookstoreEvent derives Schema:
+  case BookCreated(book: Book)
+  case BookUpdated(book: Book)
+  case BookDeleted(id: BookId)
+
+final case class BookstoreEventRecord(
+  sequence: Long,
+  event: BookstoreEvent,
+) derives Schema
+
+final case class BookstoreProjection(books: Chunk[Book]) derives Schema:
+  def find(id: BookId): Option[Book] =
+    books.find(_.id == id)
+
+object BookstoreProjection:
+  val empty: BookstoreProjection =
+    BookstoreProjection(Chunk.empty)
+
+final case class BookstoreEventRoot(
+  snapshot: BookstoreProjection,
+  journal: Chunk[BookstoreEventRecord],
+  nextSequence: Long,
+) derives Schema
+
+object BookstoreEventRoot:
+  val empty: BookstoreEventRoot =
+    BookstoreEventRoot(
+      snapshot = BookstoreProjection.empty,
+      journal = Chunk.empty,
+      nextSequence = 1L,
+    )
+
+  val descriptor: RootDescriptor[BookstoreEventRoot] =
+    RootDescriptor.fromSchema(
+      id = "bookstore-event-sourcing-root",
+      initializer = () => empty,
+    )
+
+enum BookstoreDecisionError:
+  case NotFound(id: BookId)
+  case InvalidInput(message: String)
+  case SnapshotDrift
+
+object BookstoreEventSourcing:
+  def replay(journal: Chunk[BookstoreEventRecord]): BookstoreProjection =
+    journal.foldLeft(BookstoreProjection.empty) { (projection, record) =>
+      evolve(projection, record.event)
+    }
+
+  def validate(root: BookstoreEventRoot): Either[BookstoreDecisionError, Unit] =
+    Either.cond(
+      replay(root.journal) == root.snapshot,
+      (),
+      BookstoreDecisionError.SnapshotDrift,
+    )
+
+  def decide(
+    state: BookstoreProjection,
+    command: BookstoreCommand,
+  ): Either[BookstoreDecisionError, Chunk[BookstoreEvent]] =
+    command match
+      case BookstoreCommand.Create(payload)     =>
+        validateCreate(payload).map(valid => Chunk.single(BookstoreEvent.BookCreated(valid)))
+      case BookstoreCommand.Update(id, payload) =>
+        state.find(id) match
+          case None           => Left(BookstoreDecisionError.NotFound(id))
+          case Some(existing) =>
+            validateUpdate(existing, payload).map { updated =>
+              Chunk.single(BookstoreEvent.BookUpdated(updated))
+            }
+      case BookstoreCommand.Delete(id)          =>
+        state.find(id) match
+          case None    => Left(BookstoreDecisionError.NotFound(id))
+          case Some(_) => Right(Chunk.single(BookstoreEvent.BookDeleted(id)))
+
+  def runCommand(
+    root: BookstoreEventRoot,
+    command: BookstoreCommand,
+  ): Either[BookstoreDecisionError, (Chunk[BookstoreEventRecord], BookstoreEventRoot)] =
+    for
+      _      <- validate(root)
+      events <- decide(root.snapshot, command)
+    yield
+      val records =
+        events.zipWithIndex.map { case (event, index) =>
+          BookstoreEventRecord(root.nextSequence + index.toLong, event)
+        }
+      val nextSnapshot =
+        records.foldLeft(root.snapshot) { (projection, record) =>
+          evolve(projection, record.event)
+        }
+      (
+        records,
+        root.copy(
+          snapshot = nextSnapshot,
+          journal = root.journal ++ records,
+          nextSequence = root.nextSequence + records.size.toLong,
+        ),
+      )
+
+  private def validateCreate(book: Book): Either[BookstoreDecisionError, Book] =
+    for
+      title  <- nonBlank(book.title, "Book title must not be empty")
+      author <- nonBlank(book.author, "Book author must not be empty")
+      _      <- nonNegativePrice(book.price)
+    yield book.copy(
+      title = title,
+      author = author,
+    )
+
+  private def validateUpdate(existing: Book, payload: UpdateBookRequest): Either[BookstoreDecisionError, Book] =
+    for
+      title  <- payload.title.fold[Either[BookstoreDecisionError, String]](Right(existing.title))(nonBlank(_, "Book title must not be empty"))
+      author <- payload.author.fold[Either[BookstoreDecisionError, String]](Right(existing.author))(nonBlank(_, "Book author must not be empty"))
+      price   = payload.price.getOrElse(existing.price)
+      _      <- nonNegativePrice(price)
+    yield existing.copy(
+      title = title,
+      author = author,
+      price = price,
+      tags = payload.tags.getOrElse(existing.tags),
+    )
+
+  private def nonBlank(value: String, message: String): Either[BookstoreDecisionError, String] =
+    Either.cond(value.trim.nonEmpty, value.trim, BookstoreDecisionError.InvalidInput(message))
+
+  private def nonNegativePrice(value: BigDecimal): Either[BookstoreDecisionError, Unit] =
+    Either.cond(value >= 0, (), BookstoreDecisionError.InvalidInput("Book price must be non-negative"))
+
+  private def evolve(
+    projection: BookstoreProjection,
+    event: BookstoreEvent,
+  ): BookstoreProjection =
+    event match
+      case BookstoreEvent.BookCreated(book) =>
+        projection.copy(books = projection.books :+ book)
+      case BookstoreEvent.BookUpdated(book) =>
+        projection.copy(
+          books = projection.books.map(existing => if existing.id == book.id then book else existing)
+        )
+      case BookstoreEvent.BookDeleted(id)   =>
+        projection.copy(books = projection.books.filterNot(_.id == id))

--- a/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/service/BookRepository.scala
+++ b/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/service/BookRepository.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 
 import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain.*
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
-import io.github.riccardomerolla.zio.eclipsestore.service.{ ObjectStore, Transaction }
+import io.github.riccardomerolla.zio.eclipsestore.service.{ ObjectStore, StorageOps, Transaction }
 import scala.jdk.CollectionConverters.*
 
 enum BookRepositoryError:
@@ -89,6 +89,85 @@ final case class BookRepositoryLive(store: ObjectStore[BookstoreRoot]) extends B
   override def list: IO[BookRepositoryError, Chunk[Book]] =
     withRoot.map(root => Chunk.fromIterable(root.storage.values().asScala.toList))
 
+final case class BookRepositoryEventSourcedLive(
+  store: ObjectStore[BookstoreEventRoot],
+  ops: StorageOps[BookstoreEventRoot],
+) extends BookRepository:
+  private val DecisionPrefix = "bookstore-decision:"
+
+  private def encodeDecisionError(error: BookstoreDecisionError): EclipseStoreError =
+    error match
+      case BookstoreDecisionError.NotFound(id)      =>
+        EclipseStoreError.QueryError(s"${DecisionPrefix}not-found:${id.value}", None)
+      case BookstoreDecisionError.InvalidInput(msg) =>
+        EclipseStoreError.QueryError(s"${DecisionPrefix}invalid-input:$msg", None)
+      case BookstoreDecisionError.SnapshotDrift     =>
+        EclipseStoreError.QueryError(s"${DecisionPrefix}snapshot-drift", None)
+
+  private def decodeStoreError(error: EclipseStoreError): BookRepositoryError =
+    error match
+      case EclipseStoreError.QueryError(message, _) if message.startsWith(DecisionPrefix) =>
+        decodeDecisionMessage(message.stripPrefix(DecisionPrefix))
+      case other                                                                         =>
+        BookRepositoryError.StorageFailure(other.toString)
+
+  private def decodeDecisionMessage(message: String): BookRepositoryError =
+    if message.startsWith("not-found:") then
+      BookRepositoryError.NotFound(BookId(UUID.fromString(message.stripPrefix("not-found:"))))
+    else if message.startsWith("invalid-input:") then
+      BookRepositoryError.InvalidInput(message.stripPrefix("invalid-input:"))
+    else if message == "snapshot-drift" then
+      BookRepositoryError.StorageFailure("Stored bookstore snapshot drift detected")
+    else
+      BookRepositoryError.StorageFailure(s"Unrecognized bookstore decision failure: $message")
+
+  private def process(command: BookstoreCommand): IO[BookRepositoryError, Chunk[BookstoreEventRecord]] =
+    for
+      records <- store.modify { root =>
+                   ZIO.fromEither(BookstoreEventSourcing.runCommand(root, command)).mapError { error =>
+                     encodeDecisionError(error)
+                   }
+                 }
+                 .mapError(decodeStoreError)
+      _       <- ops.checkpoint.mapError(err => BookRepositoryError.StorageFailure(err.toString))
+    yield records
+
+  private def projection: IO[BookRepositoryError, BookstoreProjection] =
+    store.load
+      .map(_.snapshot)
+      .mapError(err => BookRepositoryError.StorageFailure(err.toString))
+
+  override def create(payload: CreateBookRequest): IO[BookRepositoryError, Book] =
+    for
+      id      <- Random.nextUUID.map(BookId.apply)
+      book     = Book(id, payload.title, payload.author, payload.price, payload.tags)
+      records <- process(BookstoreCommand.Create(book))
+      created <- ZIO
+                   .fromOption(records.collectFirst { case BookstoreEventRecord(_, BookstoreEvent.BookCreated(created)) =>
+                     created
+                   })
+                   .orElseFail(BookRepositoryError.StorageFailure("Expected BookCreated event after create command"))
+    yield created
+
+  override def update(id: BookId, payload: UpdateBookRequest): IO[BookRepositoryError, Book] =
+    for
+      records <- process(BookstoreCommand.Update(id, payload))
+      updated <- ZIO
+                   .fromOption(records.collectFirst { case BookstoreEventRecord(_, BookstoreEvent.BookUpdated(book)) =>
+                     book
+                   })
+                   .orElseFail(BookRepositoryError.StorageFailure(s"Expected BookUpdated event for ${id.value}"))
+    yield updated
+
+  override def get(id: BookId): IO[BookRepositoryError, Option[Book]] =
+    projection.map(_.find(id))
+
+  override def delete(id: BookId): IO[BookRepositoryError, Unit] =
+    process(BookstoreCommand.Delete(id)).unit
+
+  override def list: IO[BookRepositoryError, Chunk[Book]] =
+    projection.map(_.books)
+
 object BookRepository:
   def create(payload: CreateBookRequest): ZIO[BookRepository, BookRepositoryError, Book] =
     ZIO.serviceWithZIO[BookRepository](_.create(payload))
@@ -107,3 +186,6 @@ object BookRepository:
 
   val live: ZLayer[ObjectStore[BookstoreRoot], Nothing, BookRepository] =
     ZLayer.fromFunction(BookRepositoryLive.apply)
+
+  val eventSourcedLive: ZLayer[ObjectStore[BookstoreEventRoot] & StorageOps[BookstoreEventRoot], Nothing, BookRepository] =
+    ZLayer.fromFunction(BookRepositoryEventSourcedLive.apply)

--- a/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/service/BookRepository.scala
+++ b/examples/bookstore/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/service/BookRepository.scala
@@ -5,7 +5,8 @@ import zio.*
 import java.util.UUID
 
 import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain.*
-import io.github.riccardomerolla.zio.eclipsestore.schema.TypedStore
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.{ ObjectStore, Transaction }
 import scala.jdk.CollectionConverters.*
 
 enum BookRepositoryError:
@@ -20,50 +21,70 @@ trait BookRepository:
   def delete(id: BookId): IO[BookRepositoryError, Unit]
   def list: IO[BookRepositoryError, Chunk[Book]]
 
-final case class BookRepositoryLive(store: TypedStore) extends BookRepository:
+final case class BookRepositoryLive(store: ObjectStore[BookstoreRoot]) extends BookRepository:
   private def withRoot: IO[BookRepositoryError, BookstoreRoot] =
-    store.typedRoot(BookstoreRoot.descriptor).mapError(err => BookRepositoryError.StorageFailure(err.toString))
+    store.load.mapError(err => BookRepositoryError.StorageFailure(err.toString))
 
-  private def persist(root: BookstoreRoot): IO[BookRepositoryError, Unit] =
-    store.storePersist(root).mapError(err => BookRepositoryError.StorageFailure(err.toString))
+  private def missing(id: BookId): EclipseStoreError =
+    EclipseStoreError.QueryError(s"Book ${id.value} not found", None)
 
   override def create(payload: CreateBookRequest): IO[BookRepositoryError, Book] =
-    for
-      root <- withRoot
-      id    = BookId(UUID.randomUUID())
-      book  = Book(id, payload.title, payload.author, payload.price, payload.tags)
-      _    <- ZIO.succeed(root.storage.put(id.value, book))
-      _    <- persist(root)
-    yield book
+    store
+      .transact(
+        Transaction.effect { root =>
+          ZIO.attempt {
+            val id   = BookId(UUID.randomUUID())
+            val book = Book(id, payload.title, payload.author, payload.price, payload.tags)
+            root.storage.put(id.value, book)
+            book
+          }.mapError(cause => EclipseStoreError.StorageError("Failed to create book", Some(cause)))
+        }
+      )
+      .mapError(err => BookRepositoryError.StorageFailure(err.toString))
 
   override def update(id: BookId, payload: UpdateBookRequest): IO[BookRepositoryError, Book] =
-    for
-      root    <- withRoot
-      updated <- Option(root.storage.get(id.value)) match
-                   case Some(existing) =>
-                     val recalculated = existing.copy(
-                       title = payload.title.getOrElse(existing.title),
-                       author = payload.author.getOrElse(existing.author),
-                       price = payload.price.getOrElse(existing.price),
-                       tags = payload.tags.getOrElse(existing.tags),
-                     )
-                     root.storage.put(id.value, recalculated)
-                     ZIO.succeed(recalculated)
-                   case None           =>
-                     ZIO.fail(BookRepositoryError.NotFound(id))
-      _       <- persist(root)
-    yield updated
+    store
+      .transact(
+        Transaction.effect { root =>
+          Option(root.storage.get(id.value)) match
+            case Some(existing) =>
+              val recalculated = existing.copy(
+                title = payload.title.getOrElse(existing.title),
+                author = payload.author.getOrElse(existing.author),
+                price = payload.price.getOrElse(existing.price),
+                tags = payload.tags.getOrElse(existing.tags),
+              )
+              ZIO.succeed {
+                root.storage.put(id.value, recalculated)
+                recalculated
+              }
+            case None           =>
+              ZIO.fail(missing(id))
+        }
+      )
+      .mapError {
+        case EclipseStoreError.QueryError(message, _) if message.contains(id.value.toString) =>
+          BookRepositoryError.NotFound(id)
+        case err                      => BookRepositoryError.StorageFailure(err.toString)
+      }
 
   override def get(id: BookId): IO[BookRepositoryError, Option[Book]] =
     withRoot.map(root => Option(root.storage.get(id.value)))
 
   override def delete(id: BookId): IO[BookRepositoryError, Unit] =
-    for
-      root <- withRoot
-      _    <- Option(root.storage.remove(id.value)) match
-                case Some(_) => persist(root)
-                case None    => ZIO.fail(BookRepositoryError.NotFound(id))
-    yield ()
+    store
+      .transact(
+        Transaction.effect { root =>
+          Option(root.storage.remove(id.value)) match
+            case Some(_) => ZIO.unit
+            case None    => ZIO.fail(missing(id))
+        }
+      )
+      .mapError {
+        case EclipseStoreError.QueryError(message, _) if message.contains(id.value.toString) =>
+          BookRepositoryError.NotFound(id)
+        case err                      => BookRepositoryError.StorageFailure(err.toString)
+      }
 
   override def list: IO[BookRepositoryError, Chunk[Book]] =
     withRoot.map(root => Chunk.fromIterable(root.storage.values().asScala.toList))
@@ -84,5 +105,5 @@ object BookRepository:
   val list: ZIO[BookRepository, BookRepositoryError, Chunk[Book]] =
     ZIO.serviceWithZIO[BookRepository](_.list)
 
-  val live: ZLayer[TypedStore, Nothing, BookRepository] =
+  val live: ZLayer[ObjectStore[BookstoreRoot], Nothing, BookRepository] =
     ZLayer.fromFunction(BookRepositoryLive.apply)

--- a/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookRepositoryEventSourcedSpec.scala
+++ b/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookRepositoryEventSourcedSpec.scala
@@ -1,0 +1,100 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.bookstore
+
+import java.nio.file.{ Files, Path }
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain.*
+import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.service.{ BookRepository, BookRepositoryError }
+import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
+
+object BookRepositoryEventSourcedSpec extends ZIOSpecDefault:
+
+  private def withTempDirectory[A](prefix: String)(use: Path => ZIO[Any, Throwable, A]): ZIO[Any, Throwable, A] =
+    ZIO.scoped {
+      ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory(prefix))) { path =>
+        ZIO.attemptBlocking {
+          if Files.exists(path) then
+            Files.walk(path).iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists)
+        }.ignore
+      }.flatMap(use)
+    }
+
+  private def repoLayer(snapshotPath: Path): ZLayer[Any, Nothing, BookRepository] =
+    ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath)) >>>
+      StorageBackend
+        .rootServices(BookstoreEventRoot.descriptor)
+        .mapError(err => new RuntimeException(err.toString))
+        .orDie >>>
+      BookRepository.eventSourcedLive
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("BookRepositoryEventSourced")(
+      test("creates, updates, and reloads books from the NativeLocal journal-backed root") {
+        withTempDirectory("bookstore-event-sourced-repo") { dir =>
+          val snapshotPath = dir.resolve("bookstore-events.snapshot.json")
+          val layer        = repoLayer(snapshotPath)
+
+          (for
+            created <- (for
+                         created <- BookRepository.create(CreateBookRequest("Event Sourcing", "Pierre", BigDecimal(42)))
+                         _       <- BookRepository.update(
+                                      created.id,
+                                      UpdateBookRequest(
+                                        title = Some("Event Sourcing in Practice"),
+                                        author = None,
+                                        price = Some(BigDecimal(45)),
+                                        tags = Some(Chunk("event-sourcing", "nativelocal")),
+                                      ),
+                                    )
+                       yield created).provideLayer(layer)
+            reopened <- (for
+                          fetched <- BookRepository.get(created.id)
+                          listed  <- BookRepository.list
+                        yield (fetched, listed)).provideLayer(layer.fresh)
+          yield assertTrue(
+            reopened._1.exists(_.title == "Event Sourcing in Practice"),
+            reopened._1.exists(_.price == BigDecimal(45)),
+            reopened._2.size == 1,
+            reopened._2.head.tags == Chunk("event-sourcing", "nativelocal"),
+          )).mapError(err => new RuntimeException(err.toString))
+        }
+      },
+      test("rejects invalid commands and preserves domain-specific errors") {
+        withTempDirectory("bookstore-event-sourced-errors") { dir =>
+          val snapshotPath = dir.resolve("bookstore-events.snapshot.json")
+
+          BookRepository
+            .create(CreateBookRequest("  ", "Author", BigDecimal(10)))
+            .provideLayer(repoLayer(snapshotPath))
+            .either
+            .map(result =>
+              assertTrue(
+                result == Left(BookRepositoryError.InvalidInput("Book title must not be empty"))
+              )
+            )
+        }
+      },
+      test("deletes books durably across a fresh reopen") {
+        withTempDirectory("bookstore-event-sourced-delete") { dir =>
+          val snapshotPath = dir.resolve("bookstore-events.snapshot.json")
+          val layer        = repoLayer(snapshotPath)
+
+          (for
+            created <- BookRepository.create(CreateBookRequest("Transient Book", "Author", BigDecimal(10))).provideLayer(layer)
+            _       <- BookRepository.delete(created.id).provideLayer(layer)
+            reopened <- (for
+                           fetched <- BookRepository.get(created.id)
+                           listed  <- BookRepository.list
+                         yield (fetched, listed)).provideLayer(layer.fresh)
+          yield assertTrue(
+            reopened._1.isEmpty,
+            reopened._2.isEmpty,
+          )).mapError(err => new RuntimeException(err.toString))
+        }
+      },
+    )

--- a/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookRepositorySpec.scala
+++ b/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookRepositorySpec.scala
@@ -3,15 +3,23 @@ package io.github.riccardomerolla.zio.eclipsestore.examples.bookstore
 import zio.*
 import zio.test.*
 
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
 import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain.*
 import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.service.BookRepository
-import io.github.riccardomerolla.zio.eclipsestore.schema.TypedStore
-import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
 
 object BookRepositorySpec extends ZIOSpecDefault:
 
   private val testLayer: ULayer[BookRepository] =
-    EclipseStoreService.inMemory >>> TypedStore.live >>> BookRepository.live
+    ZLayer.succeed(BackendConfig.InMemory("book-repository-spec")) >>>
+      StorageBackend
+        .rootServices(
+          BookstoreRoot.descriptor,
+          _.copy(rootDescriptors = Chunk.single(BookstoreRoot.descriptor)),
+        )
+        .mapError(err => new RuntimeException(err.toString))
+        .orDie >>>
+      BookRepository.live
 
   override def spec =
     suite("BookRepository")(

--- a/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookRoutesEventSourcedSpec.scala
+++ b/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookRoutesEventSourcedSpec.scala
@@ -1,0 +1,84 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.bookstore
+
+import java.nio.file.{ Files, Path }
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain.*
+import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.http.BookRoutes
+import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.service.BookRepository
+import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
+
+object BookRoutesEventSourcedSpec extends ZIOSpecDefault:
+
+  final case class JsonDecodeError(message: String) extends Exception(message)
+
+  private def withTempDirectory[A](prefix: String)(use: Path => ZIO[Any, Throwable, A]): ZIO[Any, Throwable, A] =
+    ZIO.scoped {
+      ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory(prefix))) { path =>
+        ZIO.attemptBlocking {
+          if Files.exists(path) then
+            Files.walk(path).iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists)
+        }.ignore
+      }.flatMap(use)
+    }
+
+  private def repoLayer(snapshotPath: Path): ULayer[BookRepository] =
+    ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath)) >>>
+      StorageBackend
+        .rootServices(BookstoreEventRoot.descriptor)
+        .mapError(err => new RuntimeException(err.toString))
+        .orDie >>>
+      BookRepository.eventSourcedLive
+
+  private val routes = BookRoutes.routes
+
+  private def run(request: Request): ZIO[BookRepository & Scope, Nothing, Response] =
+    routes.runZIO(request)
+
+  private def bodyText(response: Response): Task[String] =
+    response.body.asArray.map(bytes => new String(bytes, java.nio.charset.StandardCharsets.UTF_8))
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("BookRoutesEventSourced")(
+      test("creates and lists books via the event-sourced NativeLocal repository") {
+        withTempDirectory("book-routes-event-sourced") { dir =>
+          val snapshotPath = dir.resolve("bookstore-events.snapshot.json")
+          val payload      = CreateBookRequest("HTTP NativeLocal", "Author", BigDecimal(25)).toJson
+
+          (for
+            createResponse <- run(Request.post("/books", Body.fromString(payload))).provide(
+                                Scope.default,
+                                repoLayer(snapshotPath),
+                              )
+            listResponse   <- run(Request.get("/books")).provide(
+                                Scope.default,
+                                repoLayer(snapshotPath).fresh,
+                              )
+            body           <- bodyText(listResponse)
+            books          <- ZIO.fromEither(body.fromJson[List[Book]].left.map(JsonDecodeError.apply))
+          yield assertTrue(
+            createResponse.status == Status.Ok,
+            books.map(_.title) == List("HTTP NativeLocal"),
+          )).mapError(err => new RuntimeException(err.toString))
+        }
+      },
+      test("returns 404 for a missing book via the event-sourced repository") {
+        withTempDirectory("book-routes-event-sourced-404") { dir =>
+          val snapshotPath = dir.resolve("bookstore-events.snapshot.json")
+
+          run(Request.get("/books/00000000-0000-0000-0000-000000000000"))
+            .provide(
+              Scope.default,
+              repoLayer(snapshotPath),
+            )
+            .map(response => assertTrue(response.status == Status.NotFound))
+        }
+      },
+    )

--- a/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookRoutesSpec.scala
+++ b/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookRoutesSpec.scala
@@ -5,18 +5,26 @@ import zio.http.*
 import zio.json.*
 import zio.test.*
 
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
 import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain.*
 import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.http.BookRoutes
 import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.service.BookRepository
-import io.github.riccardomerolla.zio.eclipsestore.schema.TypedStore
-import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+import io.github.riccardomerolla.zio.eclipsestore.service.StorageBackend
 
 object BookRoutesSpec extends ZIOSpecDefault:
 
   final case class JsonDecodeError(message: String) extends Exception(message)
 
   private val repoLayer: ULayer[BookRepository] =
-    EclipseStoreService.inMemory >>> TypedStore.live >>> BookRepository.live
+    ZLayer.succeed(BackendConfig.InMemory("book-routes-spec")) >>>
+      StorageBackend
+        .rootServices(
+          BookstoreRoot.descriptor,
+          _.copy(rootDescriptors = Chunk.single(BookstoreRoot.descriptor)),
+        )
+        .mapError(err => new RuntimeException(err.toString))
+        .orDie >>>
+      BookRepository.live
 
   private val routes = BookRoutes.routes
 

--- a/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflowSpec.scala
+++ b/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflowSpec.scala
@@ -22,41 +22,53 @@ object BookstoreWorkflowSpec extends ZIOSpecDefault:
       }.flatMap(use)
     }
 
+  private def persistenceScenario(backendConfig: BackendConfig, backupPath: Path) =
+    val layer = BookstoreWorkflow.layer(backendConfig)
+
+    val firstRun =
+      for
+        _ <- BookstoreWorkflow.createBook(
+               CreateBookRequest("Zionomicon", "John de Goes", BigDecimal(49), Chunk("zio", "scala"))
+             )
+        _ <- BookstoreWorkflow.createBook(
+               CreateBookRequest("Inside EclipseStore", "Riccardo", BigDecimal(39), Chunk("storage"))
+             )
+        beforeRestart <- BookstoreWorkflow.inventory
+        _             <- BookstoreWorkflow.backup(backupPath)
+      yield beforeRestart
+
+    val secondRun = BookstoreWorkflow.inventory.provideLayer(layer)
+
+    for
+      initial     <- firstRun.provideLayer(layer).either
+      reloaded    <- secondRun.either
+      backupFiles <- ZIO.attemptBlocking {
+                       Files.walk(backupPath).iterator().asScala.count(Files.isRegularFile(_))
+                     }
+    yield (initial, reloaded) match
+      case (Right(beforeRestart), Right(afterRestart)) =>
+        assertTrue(
+          beforeRestart.sorted.map(_.title) == Chunk("Inside EclipseStore", "Zionomicon"),
+          afterRestart.sorted.map(_.title) == Chunk("Inside EclipseStore", "Zionomicon"),
+          backupFiles > 0,
+        )
+      case _                                       =>
+        assertTrue(false)
+
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("BookstoreWorkflow")(
-      test("creates, queries, backs up, and reloads data after restart") {
+      test("creates, queries, backs up, and reloads data after restart on filesystem backend") {
         withTempDirectory("bookstore-workflow") { dataPath =>
           withTempDirectory("bookstore-backup") { backupPath =>
-            val layer    = BookstoreWorkflow.layer(BackendConfig.FileSystem(dataPath))
-            val firstRun =
-              for
-                _ <- BookstoreWorkflow.createBook(
-                       CreateBookRequest("Zionomicon", "John de Goes", BigDecimal(49), Chunk("zio", "scala"))
-                     )
-                _ <- BookstoreWorkflow.createBook(
-                       CreateBookRequest("Inside EclipseStore", "Riccardo", BigDecimal(39), Chunk("storage"))
-                     )
-                beforeRestart <- BookstoreWorkflow.inventory
-                _             <- BookstoreWorkflow.backup(backupPath)
-              yield beforeRestart
-
-            val secondRun = BookstoreWorkflow.inventory.provideLayer(layer)
-
-            for
-              initial <- firstRun.provideLayer(layer).either
-              reloaded <- secondRun.either
-              backupFiles <- ZIO.attemptBlocking {
-                               Files.walk(backupPath).iterator().asScala.count(Files.isRegularFile(_))
-                             }
-            yield (initial, reloaded) match
-              case (Right(beforeRestart), Right(afterRestart)) =>
-                assertTrue(
-                  beforeRestart.sorted.map(_.title) == Chunk("Inside EclipseStore", "Zionomicon"),
-                  afterRestart.sorted.map(_.title) == Chunk("Inside EclipseStore", "Zionomicon"),
-                  backupFiles > 0,
-                )
-              case _                                       =>
-                assertTrue(false)
+            persistenceScenario(BackendConfig.FileSystem(dataPath), backupPath)
+          }
+        }
+      },
+      test("creates, queries, backs up, and reloads data after restart on NativeLocal backend") {
+        withTempDirectory("bookstore-native-local") { snapshotDir =>
+          withTempDirectory("bookstore-native-backup") { backupPath =>
+            val snapshotPath = snapshotDir.resolve("bookstore-root.json")
+            persistenceScenario(BackendConfig.NativeLocal(snapshotPath), backupPath)
           }
         }
       },

--- a/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflowSpec.scala
+++ b/examples/bookstore/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/bookstore/BookstoreWorkflowSpec.scala
@@ -1,0 +1,109 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.bookstore
+
+import java.nio.file.{ Files, Path }
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.examples.bookstore.domain.{ BookId, CreateBookRequest }
+
+object BookstoreWorkflowSpec extends ZIOSpecDefault:
+
+  private def withTempDirectory[A](prefix: String)(use: Path => ZIO[Any, Throwable, A]): ZIO[Any, Throwable, A] =
+    ZIO.scoped {
+      ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory(prefix))) { path =>
+        ZIO.attemptBlocking {
+          if Files.exists(path) then
+            Files.walk(path).iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists)
+        }.ignore
+      }.flatMap(use)
+    }
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("BookstoreWorkflow")(
+      test("creates, queries, backs up, and reloads data after restart") {
+        withTempDirectory("bookstore-workflow") { dataPath =>
+          withTempDirectory("bookstore-backup") { backupPath =>
+            val layer    = BookstoreWorkflow.layer(BackendConfig.FileSystem(dataPath))
+            val firstRun =
+              for
+                _ <- BookstoreWorkflow.createBook(
+                       CreateBookRequest("Zionomicon", "John de Goes", BigDecimal(49), Chunk("zio", "scala"))
+                     )
+                _ <- BookstoreWorkflow.createBook(
+                       CreateBookRequest("Inside EclipseStore", "Riccardo", BigDecimal(39), Chunk("storage"))
+                     )
+                beforeRestart <- BookstoreWorkflow.inventory
+                _             <- BookstoreWorkflow.backup(backupPath)
+              yield beforeRestart
+
+            val secondRun = BookstoreWorkflow.inventory.provideLayer(layer)
+
+            for
+              initial <- firstRun.provideLayer(layer).either
+              reloaded <- secondRun.either
+              backupFiles <- ZIO.attemptBlocking {
+                               Files.walk(backupPath).iterator().asScala.count(Files.isRegularFile(_))
+                             }
+            yield (initial, reloaded) match
+              case (Right(beforeRestart), Right(afterRestart)) =>
+                assertTrue(
+                  beforeRestart.sorted.map(_.title) == Chunk("Inside EclipseStore", "Zionomicon"),
+                  afterRestart.sorted.map(_.title) == Chunk("Inside EclipseStore", "Zionomicon"),
+                  backupFiles > 0,
+                )
+              case _                                       =>
+                assertTrue(false)
+          }
+        }
+      },
+      test("legacy sample records receive v2 defaults during migration") {
+        val legacy = LegacyBookRecord(
+          id = BookId(java.util.UUID.randomUUID()),
+          title = "Legacy Scala Book",
+          author = "Vintage Author",
+          price = BigDecimal(19),
+        )
+
+        assertZIO(
+          BookstoreMigrations.migrate(legacy).either.map {
+            case Right(migrated) =>
+              migrated.id == legacy.id &&
+              migrated.title == legacy.title &&
+              migrated.author == legacy.author &&
+              migrated.price == legacy.price &&
+              migrated.tags.isEmpty &&
+              migrated.shelf == "general"
+            case Left(_)         =>
+              false
+          }
+        )(Assertion.isTrue)
+      },
+      test("legacy migration preserves common fields for arbitrary samples") {
+        check(
+          Gen.uuid,
+          Gen.alphaNumericStringBounded(1, 24),
+          Gen.alphaNumericStringBounded(1, 24),
+          Gen.bigDecimal(BigDecimal(-1000), BigDecimal(1000)),
+        ) { (id, title, author, price) =>
+          val legacy = LegacyBookRecord(BookId(id), title, author, price)
+
+          assertZIO(
+            BookstoreMigrations.migrate(legacy).either.map {
+              case Right(record) =>
+                record.id == legacy.id &&
+                record.title == title &&
+                record.author == author &&
+                record.price == price &&
+                record.tags == Chunk.empty &&
+                record.shelf == "general"
+              case Left(_)       =>
+                false
+            }
+          )(Assertion.isTrue)
+        }
+      },
+    )

--- a/examples/gigamap-cli/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/gigamap/SemanticSearchApp.scala
+++ b/examples/gigamap-cli/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/gigamap/SemanticSearchApp.scala
@@ -1,0 +1,107 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.gigamap
+
+import zio.*
+import zio.Console.printLine
+
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.config.{ GigaMapDefinition, GigaMapIndex, GigaMapVectorIndex }
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.domain.{ GigaMapQuery, GigaMapScored }
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.error.GigaMapError
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.service.GigaMap
+import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+
+final case class SemanticDocument(
+  id: String,
+  title: String,
+  topic: String,
+  body: String,
+  embedding: Chunk[Float],
+)
+
+trait SemanticSearchSample:
+  def indexAll(documents: Chunk[SemanticDocument]): IO[GigaMapError, Unit]
+  def nearestNeighbors(queryVector: Chunk[Float], limit: Int): IO[GigaMapError, Chunk[GigaMapScored[SemanticDocument]]]
+  def byTopic(topic: String): IO[GigaMapError, Chunk[SemanticDocument]]
+
+final case class SemanticSearchSampleLive(
+  map: GigaMap[String, SemanticDocument]
+) extends SemanticSearchSample:
+  override def indexAll(documents: Chunk[SemanticDocument]): IO[GigaMapError, Unit] =
+    map.putAll(documents.map(document => document.id -> document))
+
+  override def nearestNeighbors(
+    queryVector: Chunk[Float],
+    limit: Int,
+  ): IO[GigaMapError, Chunk[GigaMapScored[SemanticDocument]]] =
+    map.query(GigaMapQuery.VectorSearch("embedding", queryVector, limit))
+
+  override def byTopic(topic: String): IO[GigaMapError, Chunk[SemanticDocument]] =
+    map.query(GigaMapQuery.ByIndex("topic", topic))
+
+object SemanticSearchSample:
+  val definition: GigaMapDefinition[String, SemanticDocument] =
+    GigaMapDefinition(
+      name = "semantic-search-sample",
+      indexes = Chunk(
+        GigaMapIndex.single("topic", _.topic)
+      ),
+      vectorIndexes = Chunk(
+        GigaMapVectorIndex(
+          name = "embedding",
+          extract = _.embedding.toArray,
+          dimension = 3,
+        )
+      ),
+    )
+
+  val live: ZLayer[EclipseStoreService, GigaMapError, SemanticSearchSample] =
+    GigaMap.make(definition) >>> ZLayer.fromFunction(SemanticSearchSampleLive.apply)
+
+  def indexAll(documents: Chunk[SemanticDocument]): ZIO[SemanticSearchSample, GigaMapError, Unit] =
+    ZIO.serviceWithZIO[SemanticSearchSample](_.indexAll(documents))
+
+  def nearestNeighbors(
+    queryVector: Chunk[Float],
+    limit: Int = 3,
+  ): ZIO[SemanticSearchSample, GigaMapError, Chunk[GigaMapScored[SemanticDocument]]] =
+    ZIO.serviceWithZIO[SemanticSearchSample](_.nearestNeighbors(queryVector, limit))
+
+  def byTopic(topic: String): ZIO[SemanticSearchSample, GigaMapError, Chunk[SemanticDocument]] =
+    ZIO.serviceWithZIO[SemanticSearchSample](_.byTopic(topic))
+
+object SemanticSearchApp extends ZIOAppDefault:
+  private val sampleDocuments = Chunk(
+    SemanticDocument(
+      id = "zio-engine",
+      title = "Scala-native persistence engine",
+      topic = "architecture",
+      body = "Typed roots, ACID transactions, and ZLayer storage targets.",
+      embedding = Chunk(0.99f, 0.05f, 0.01f),
+    ),
+    SemanticDocument(
+      id = "vector-search",
+      title = "Vector indexes in GigaMap",
+      topic = "search",
+      body = "Approximate nearest-neighbor queries for semantic lookup.",
+      embedding = Chunk(0.96f, 0.02f, 0.04f),
+    ),
+    SemanticDocument(
+      id = "ops-runbook",
+      title = "Operations and backup runbook",
+      topic = "operations",
+      body = "Checkpoint, backup, restore, and housekeeping flows.",
+      embedding = Chunk(0.08f, 0.98f, 0.01f),
+    ),
+  )
+
+  override def run: URIO[ZIOAppArgs & Scope, Any] =
+    (for
+      _       <- SemanticSearchSample.indexAll(sampleDocuments)
+      matches <- SemanticSearchSample.nearestNeighbors(Chunk(1.0f, 0.0f, 0.0f), limit = 2)
+      _       <- ZIO.foreachDiscard(matches) { scored =>
+                   printLine(f"${scored.value.title} [${scored.score}%.3f]").orDie
+                 }
+    yield ())
+      .provide(
+        EclipseStoreService.inMemory,
+        SemanticSearchSample.live.orDie,
+      )

--- a/examples/gigamap-cli/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/gigamap/SemanticSearchAppSpec.scala
+++ b/examples/gigamap-cli/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/gigamap/SemanticSearchAppSpec.scala
@@ -1,0 +1,55 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.gigamap
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+
+object SemanticSearchAppSpec extends ZIOSpecDefault:
+
+  private val sampleLayer =
+    EclipseStoreService.inMemory >>> SemanticSearchSample.live.orDie
+
+  private val documents = Chunk(
+    SemanticDocument(
+      id = "engine",
+      title = "Scala-native engine",
+      topic = "architecture",
+      body = "Typed roots and ACID semantics.",
+      embedding = Chunk(0.99f, 0.02f, 0.01f),
+    ),
+    SemanticDocument(
+      id = "vectors",
+      title = "Vector indexes",
+      topic = "search",
+      body = "Nearest-neighbor retrieval in GigaMap.",
+      embedding = Chunk(0.97f, 0.03f, 0.01f),
+    ),
+    SemanticDocument(
+      id = "backup",
+      title = "Backup workflow",
+      topic = "operations",
+      body = "Operational lifecycle and restore commands.",
+      embedding = Chunk(0.02f, 0.98f, 0.01f),
+    ),
+  )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("SemanticSearchSample")(
+      test("semantic queries return the nearest neighbors first") {
+        (for
+          _       <- SemanticSearchSample.indexAll(documents)
+          matches <- SemanticSearchSample.nearestNeighbors(Chunk(1.0f, 0.0f, 0.0f), limit = 2)
+        yield assertTrue(
+          matches.map(_.value.id) == Chunk("engine", "vectors")
+        )).provideLayer(sampleLayer)
+      },
+      test("topic index lookup stays available alongside vector search") {
+        (for
+          _       <- SemanticSearchSample.indexAll(documents)
+          matches <- SemanticSearchSample.byTopic("operations")
+        yield assertTrue(
+          matches.map(_.id) == Chunk("backup")
+        )).provideLayer(sampleLayer)
+      },
+    )

--- a/gigamap/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/config/GigaMapDefinition.scala
+++ b/gigamap/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/config/GigaMapDefinition.scala
@@ -2,11 +2,14 @@ package io.github.riccardomerolla.zio.eclipsestore.gigamap.config
 
 import zio.Chunk
 
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.vector.SimilarityFunction
+
 /** Describes a named GigaMap instance together with optional indexes. */
 final case class GigaMapDefinition[K, V](
   name: String,
   indexes: Chunk[GigaMapIndex[V, ?]] = Chunk.empty[GigaMapIndex[V, Any]],
   vectorIndexes: Chunk[GigaMapVectorIndex[V]] = Chunk.empty[GigaMapVectorIndex[V]],
+  spatialIndexes: Chunk[GigaMapSpatialIndex[V]] = Chunk.empty[GigaMapSpatialIndex[V]],
   autoPersist: Boolean = true,
 ):
   private[gigamap] val anyIndexes: Chunk[GigaMapIndex[V, Any]] =
@@ -25,4 +28,12 @@ final case class GigaMapVectorIndex[V](
   name: String,
   extract: V => Array[Float],
   dimension: Int,
+  similarityFunction: SimilarityFunction = SimilarityFunction.Cosine,
+)
+
+final case class GeoPoint(latitude: Double, longitude: Double)
+
+final case class GigaMapSpatialIndex[V](
+  name: String,
+  extract: V => GeoPoint,
 )

--- a/gigamap/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/domain/GigaMapQuery.scala
+++ b/gigamap/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/domain/GigaMapQuery.scala
@@ -2,7 +2,13 @@ package io.github.riccardomerolla.zio.eclipsestore.gigamap.domain
 
 import zio.Chunk
 
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.config.GeoPoint
+
 sealed trait GigaMapQuery[V, +A]
+
+sealed trait GigaMapPredicate[V]
+
+final case class GigaMapScored[V](value: V, score: Float)
 
 object GigaMapQuery:
   final case class All[V]()                               extends GigaMapQuery[V, Chunk[V]]
@@ -14,4 +20,33 @@ object GigaMapQuery:
     limit: Int = 10,
     threshold: Option[Float] = None,
   ) extends GigaMapQuery[V, Chunk[V]]
+  final case class VectorSearch[V](
+    indexName: String,
+    vector: Chunk[Float],
+    limit: Int = 10,
+    minScore: Option[Float] = None,
+  ) extends GigaMapQuery[V, Chunk[GigaMapScored[V]]]
+  final case class SpatialRadius[V](
+    indexName: String,
+    center: GeoPoint,
+    radiusKilometers: Double,
+  ) extends GigaMapQuery[V, Chunk[V]]
+  final case class Composite[V](
+    predicates: Chunk[GigaMapPredicate[V]]
+  ) extends GigaMapQuery[V, Chunk[V]]
   final case class Count[V]()                             extends GigaMapQuery[V, Long]
+
+object GigaMapPredicate:
+  final case class Filter[V](predicate: V => Boolean)     extends GigaMapPredicate[V]
+  final case class ByIndex[V, A](index: String, value: A) extends GigaMapPredicate[V]
+  final case class VectorSearch[V](
+    indexName: String,
+    vector: Chunk[Float],
+    limit: Int = 10,
+    minScore: Option[Float] = None,
+  ) extends GigaMapPredicate[V]
+  final case class SpatialRadius[V](
+    indexName: String,
+    center: GeoPoint,
+    radiusKilometers: Double,
+  ) extends GigaMapPredicate[V]

--- a/gigamap/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/error/GigaMapError.scala
+++ b/gigamap/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/error/GigaMapError.scala
@@ -1,6 +1,8 @@
 package io.github.riccardomerolla.zio.eclipsestore.gigamap.error
 
-sealed trait GigaMapError extends Throwable
+import io.github.riccardomerolla.zio.eclipsestore.error.PersistenceError
+
+sealed trait GigaMapError extends Throwable with PersistenceError
 
 object GigaMapError:
   final case class StorageFailure(message: String, cause: Option[Throwable] = None) extends GigaMapError:

--- a/gigamap/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/error/GigaMapError.scala
+++ b/gigamap/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/error/GigaMapError.scala
@@ -12,5 +12,13 @@ object GigaMapError:
   final case class IndexNotDefined(index: String) extends GigaMapError:
     override def getMessage: String = s"Index '$index' is not defined for this GigaMap"
 
+  final case class InvalidVectorQuery(index: String, expectedDimension: Int, actualDimension: Int) extends GigaMapError:
+    override def getMessage: String =
+      s"Vector query for index '$index' expected dimension $expectedDimension but received $actualDimension"
+
+  final case class InvalidSpatialQuery(index: String, radiusKilometers: Double) extends GigaMapError:
+    override def getMessage: String =
+      s"Spatial query for index '$index' requires a non-negative radius, received $radiusKilometers"
+
   case object EmptyRegistry extends GigaMapError:
     override def getMessage: String = "GigaMap registry is not initialized"

--- a/gigamap/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/service/GigaMap.scala
+++ b/gigamap/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/service/GigaMap.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentHashMap.KeySetView
 
 import scala.jdk.CollectionConverters.*
+import scala.math.{ atan2, cos, sin, sqrt }
 
 import zio.*
 
@@ -64,8 +65,13 @@ final private class GigaMapLive[K, V: Tag](
 
   private val vectorIndexes = definition.vectorIndexes
 
+  private val spatialIndexes = definition.spatialIndexes
+
   // Store vector embeddings for similarity search
   private val vectorStore: ConcurrentHashMap[String, ConcurrentHashMap[Any, Array[Float]]] =
+    new ConcurrentHashMap()
+
+  private val spatialStore: ConcurrentHashMap[String, ConcurrentHashMap[Any, GeoPoint]] =
     new ConcurrentHashMap()
 
   override def put(key: K, value: V): IO[GigaMapError, Unit] =
@@ -76,6 +82,7 @@ final private class GigaMapLive[K, V: Tag](
                     }
         _        <- updateIndexes(key, previous, Some(value))
         _        <- updateVectorIndexes(key, previous, Some(value))
+        _        <- updateSpatialIndexes(key, previous, Some(value))
         _        <- persistIfNeeded
       yield ()
     }
@@ -92,6 +99,7 @@ final private class GigaMapLive[K, V: Tag](
         removed <- attempt(Option(map.remove(key)).map(_.asInstanceOf[V]))
         _       <- updateIndexes(key, removed, None)
         _       <- updateVectorIndexes(key, removed, None)
+        _       <- updateSpatialIndexes(key, removed, None)
         _       <- persistIfNeeded
       yield removed
     }
@@ -102,6 +110,7 @@ final private class GigaMapLive[K, V: Tag](
         map.clear()
         indexState.values().asScala.foreach(_.clear())
         vectorStore.values().asScala.foreach(_.clear())
+        spatialStore.values().asScala.foreach(_.clear())
       } *> persistIfNeeded
     }
 
@@ -136,25 +145,42 @@ final private class GigaMapLive[K, V: Tag](
       case GigaMapQuery.ByIndex(indexName, value)  =>
         for result <- byIndex(indexName, value)
         yield result.asInstanceOf[A]
+      case GigaMapQuery.VectorSearch(indexName, vector, limit, minScore) =>
+        vectorSearch(indexName, vector, limit, minScore).asInstanceOf[IO[GigaMapError, A]]
       case query: GigaMapQuery.VectorSimilarity[V] =>
-        for result <- vectorSimilaritySearch(query.indexName, query.vector, query.limit, query.threshold)
-        yield result.asInstanceOf[A]
+        vectorSearch(query.indexName, Chunk.fromArray(query.vector), query.limit, query.threshold)
+          .map(_.map(_.value))
+          .asInstanceOf[IO[GigaMapError, A]]
+      case GigaMapQuery.SpatialRadius(indexName, center, radiusKilometers) =>
+        spatialRadius(indexName, center, radiusKilometers).asInstanceOf[IO[GigaMapError, A]]
+      case GigaMapQuery.Composite(predicates) =>
+        composite(predicates).asInstanceOf[IO[GigaMapError, A]]
       case GigaMapQuery.Count()                    =>
         size.map(_.toLong).asInstanceOf[IO[GigaMapError, A]]
 
   override def persist: IO[GigaMapError, Unit] =
     persistState
 
-  private def byIndex(indexName: String, value: Any): IO[GigaMapError, Chunk[V]] =
+  private def byIndexKeys(indexName: String, value: Any): IO[GigaMapError, Chunk[Any]] =
     for
       state   <- ZIO.fromOption(Option(indexState.get(indexName))).orElseFail(IndexNotDefined(indexName))
       keysOpt  = Option(state.get(value))
-      entries <- attempt {
-                   val data = keysOpt
-                     .map(_.asScala.toList.flatMap(key => Option(map.get(key)).map(_.asInstanceOf[V])))
-                     .getOrElse(Nil)
-                   Chunk.fromIterable(data)
-                 }
+      entries <- attempt(Chunk.fromIterable(keysOpt.map(_.asScala.toList).getOrElse(Nil)))
+    yield entries
+
+  private def filterKeys(predicate: V => Boolean): IO[GigaMapError, Chunk[Any]] =
+    attempt {
+      Chunk.fromIterable(
+        map.entrySet().asScala.collect {
+          case entry if predicate(entry.getValue.asInstanceOf[V]) => entry.getKey
+        }
+      )
+    }
+
+  private def byIndex(indexName: String, value: Any): IO[GigaMapError, Chunk[V]] =
+    for
+      keys    <- byIndexKeys(indexName, value)
+      entries <- attempt(keys.flatMap(key => Option(map.get(key)).map(_.asInstanceOf[V])))
     yield entries
 
   private def updateVectorIndexes(key: K, oldValue: Option[V], newValue: Option[V]): IO[GigaMapError, Unit] =
@@ -173,47 +199,104 @@ final private class GigaMapLive[K, V: Tag](
       }
     }
 
-  private def vectorSimilaritySearch(
+  private def vectorSearchKeys(
     indexName: String,
-    queryVector: Array[Float],
+    queryVector: Chunk[Float],
     limit: Int,
-    threshold: Option[Float],
-  ): IO[GigaMapError, Chunk[V]] =
+    minScore: Option[Float],
+  ): IO[GigaMapError, Chunk[(Any, Float)]] =
     for
       vectorIndexOpt <- attempt(vectorIndexes.find(_.name == indexName))
       vectorIndex    <- ZIO.fromOption(vectorIndexOpt).orElseFail(IndexNotDefined(indexName))
+      query           = queryVector.toArray
+      _              <-
+        if query.length == vectorIndex.dimension then ZIO.unit
+        else ZIO.fail(InvalidVectorQuery(indexName, vectorIndex.dimension, query.length))
       store          <- attempt(vectorStore.computeIfAbsent(indexName, _ => new ConcurrentHashMap[Any, Array[Float]]()))
       results        <- attempt {
-                          val scores = store.entrySet().asScala
-                            .map { entry =>
-                              val key      = entry.getKey
-                              val vector   = entry.getValue
-                              val distance = cosineSimilarity(queryVector, vector)
-                              (key, distance)
-                            }
-                            .filter {
-                              case (_, distance) =>
-                                threshold.forall(t => distance >= t)
-                            }
-                            .toList
-                            .sortBy { case (_, distance) => -distance } // Sort by distance descending
-                            .take(limit)
-                            .map {
-                              case (key, _) =>
-                                Option(map.get(key)).map(_.asInstanceOf[V])
-                            }
-                            .flatten
-                          Chunk.fromIterable(scores)
+                          Chunk.fromIterable(
+                            store.entrySet().asScala
+                              .map { entry =>
+                                val key    = entry.getKey
+                                val vector = entry.getValue
+                                val score  = similarity(vectorIndex.similarityFunction, query, vector)
+                                (key, score)
+                              }
+                              .filter { case (_, score) => minScore.forall(score >= _) }
+                              .toList
+                              .sortBy { case (_, score) => -score }
+                              .take(limit)
+                          )
                         }
     yield results
 
-  private def cosineSimilarity(vecA: Array[Float], vecB: Array[Float]): Float =
-    if vecA.length != vecB.length then 0f
+  private def vectorSearch(
+    indexName: String,
+    queryVector: Chunk[Float],
+    limit: Int,
+    minScore: Option[Float],
+  ): IO[GigaMapError, Chunk[GigaMapScored[V]]] =
+    for
+      ranked <- vectorSearchKeys(indexName, queryVector, limit, minScore)
+      values <- attempt {
+                  ranked.flatMap { case (key, score) =>
+                    Option(map.get(key)).map(value => GigaMapScored(value.asInstanceOf[V], score))
+                  }
+                }
+    yield values
+
+  private def spatialRadiusKeys(indexName: String, center: GeoPoint, radiusKilometers: Double): IO[GigaMapError, Chunk[Any]] =
+    if radiusKilometers < 0 then ZIO.fail(InvalidSpatialQuery(indexName, radiusKilometers))
     else
-      val dotProduct = (vecA zip vecB).foldLeft(0f) { case (sum, (a, b)) => sum + (a * b) }
-      val magnitudeA = Math.sqrt(vecA.foldLeft(0f) { case (sum, a) => sum + (a * a) })
-      val magnitudeB = Math.sqrt(vecB.foldLeft(0f) { case (sum, b) => sum + (b * b) })
-      if magnitudeA == 0 || magnitudeB == 0 then 0f else (dotProduct / (magnitudeA * magnitudeB)).toFloat
+      for
+        store <- ZIO.fromOption(Option(spatialStore.get(indexName))).orElseFail(IndexNotDefined(indexName))
+        keys  <- attempt {
+                  Chunk.fromIterable(
+                    store.entrySet().asScala.collect {
+                      case entry if haversineKilometers(center, entry.getValue) <= radiusKilometers => entry.getKey
+                    }
+                  )
+                }
+      yield keys
+
+  private def spatialRadius(indexName: String, center: GeoPoint, radiusKilometers: Double): IO[GigaMapError, Chunk[V]] =
+    for
+      keys   <- spatialRadiusKeys(indexName, center, radiusKilometers)
+      values <- attempt(keys.flatMap(key => Option(map.get(key)).map(_.asInstanceOf[V])))
+    yield values
+
+  private def composite(predicates: Chunk[GigaMapPredicate[V]]): IO[GigaMapError, Chunk[V]] =
+    if predicates.isEmpty then query(GigaMapQuery.All[V]())
+    else
+      for
+        matched      <- ZIO.foreach(predicates)(predicateKeys)
+        intersection  = matched.map(_.toSet).reduce(_ intersect _)
+        values       <- attempt {
+                          Chunk.fromIterable(
+                            map.entrySet().asScala.collect {
+                              case entry if intersection.contains(entry.getKey) => entry.getValue.asInstanceOf[V]
+                            }
+                          )
+                        }
+      yield values
+
+  private def predicateKeys(predicate: GigaMapPredicate[V]): IO[GigaMapError, Chunk[Any]] =
+    predicate match
+      case GigaMapPredicate.Filter(pred)                             => filterKeys(pred)
+      case GigaMapPredicate.ByIndex(index, value)                    => byIndexKeys(index, value)
+      case GigaMapPredicate.VectorSearch(index, vector, limit, min) => vectorSearchKeys(index, vector, limit, min).map(_.map(_._1))
+      case GigaMapPredicate.SpatialRadius(index, center, radius)     => spatialRadiusKeys(index, center, radius)
+
+  private def updateSpatialIndexes(key: K, oldValue: Option[V], newValue: Option[V]): IO[GigaMapError, Unit] =
+    attempt {
+      spatialIndexes.foreach { spatialIndex =>
+        val name  = spatialIndex.name
+        val store =
+          spatialStore.computeIfAbsent(name, _ => new ConcurrentHashMap[Any, GeoPoint]())
+        oldValue.foreach(_ => store.remove(key))
+        newValue.foreach(value => store.put(key, spatialIndex.extract(value)))
+      }
+    }
 
   private def updateIndexes(key: K, oldValue: Option[V], newValue: Option[V]): IO[GigaMapError, Unit] =
     attempt {
@@ -254,13 +337,48 @@ final private class GigaMapLive[K, V: Tag](
         .toList
     val indexBuckets              =
       indexMaps.flatMap(_.values().asScala.toList)
+    val vectorMaps                =
+      vectorStore.values().asScala.toList
+    val spatialMaps               =
+      spatialStore.values().asScala.toList
     val baseTargets: List[AnyRef] =
-      List(registry, registryMaps, registryIndexes, map, indexState)
+      List(registry, registryMaps, registryIndexes, map, indexState, vectorStore, spatialStore)
     val targets: List[AnyRef]     =
-      baseTargets ++ indexMaps ++ indexBuckets
+      baseTargets ++ indexMaps ++ indexBuckets ++ vectorMaps ++ spatialMaps
     store
       .persistAll[AnyRef](targets)
       .mapError(e => StorageFailure("Failed to persist GigaMap state", Some(new RuntimeException(e.toString))))
+
+  private def similarity(
+    function: io.github.riccardomerolla.zio.eclipsestore.gigamap.vector.SimilarityFunction,
+    a: Array[Float],
+    b: Array[Float],
+  ): Float =
+    function match
+      case io.github.riccardomerolla.zio.eclipsestore.gigamap.vector.SimilarityFunction.Cosine =>
+        val dot  = a.indices.foldLeft(0f)((acc, index) => acc + a(index) * b(index))
+        val magA = sqrt(a.foldLeft(0f)((acc, value) => acc + value * value).toDouble).toFloat
+        val magB = sqrt(b.foldLeft(0f)((acc, value) => acc + value * value).toDouble).toFloat
+        if magA == 0f || magB == 0f then 0f else dot / (magA * magB)
+      case io.github.riccardomerolla.zio.eclipsestore.gigamap.vector.SimilarityFunction.DotProduct =>
+        a.indices.foldLeft(0f)((acc, index) => acc + a(index) * b(index))
+      case io.github.riccardomerolla.zio.eclipsestore.gigamap.vector.SimilarityFunction.Euclidean =>
+        -a.indices.foldLeft(0f) { (acc, index) =>
+          val delta = a(index) - b(index)
+          acc + (delta * delta)
+        }
+
+  private def haversineKilometers(a: GeoPoint, b: GeoPoint): Double =
+    val earthRadiusKm = 6371.0
+    val dLat          = Math.toRadians(b.latitude - a.latitude)
+    val dLon          = Math.toRadians(b.longitude - a.longitude)
+    val lat1          = Math.toRadians(a.latitude)
+    val lat2          = Math.toRadians(b.latitude)
+    val x             =
+      sin(dLat / 2) * sin(dLat / 2) +
+        cos(lat1) * cos(lat2) * sin(dLon / 2) * sin(dLon / 2)
+    val c             = 2 * atan2(sqrt(x), sqrt(1 - x))
+    earthRadiusKm * c
 
   private def attempt[A](thunk: => A): IO[GigaMapError, A] =
     ZIO.attempt(thunk).mapError(e => StorageFailure("GigaMap operation failed", Some(e)))

--- a/gigamap/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/AdvancedIndexingSpec.scala
+++ b/gigamap/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/AdvancedIndexingSpec.scala
@@ -1,0 +1,187 @@
+package io.github.riccardomerolla.zio.eclipsestore.gigamap
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.config.*
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.domain.{ GigaMapPredicate, GigaMapQuery }
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.error.GigaMapError
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.service.GigaMap
+import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+
+final case class PlaceDocument(
+  id: String,
+  city: String,
+  status: String,
+  location: GeoPoint,
+  embedding: Array[Float],
+)
+
+object AdvancedIndexingSpec extends ZIOSpecDefault:
+  private val definition =
+    GigaMapDefinition[String, PlaceDocument](
+      name = "advanced-documents",
+      indexes = Chunk(
+        GigaMapIndex.single("city", _.city),
+        GigaMapIndex.single("status", _.status),
+      ),
+      vectorIndexes = Chunk(
+        GigaMapVectorIndex("embedding", _.embedding, dimension = 3)
+      ),
+      spatialIndexes = Chunk(
+        GigaMapSpatialIndex("location", _.location)
+      ),
+      autoPersist = false,
+    )
+
+  private val layer =
+    EclipseStoreService.inMemory >>> GigaMap.make(definition)
+
+  private val romeCenter   = GeoPoint(41.9028, 12.4964)
+  private val parisCenter  = GeoPoint(48.8566, 2.3522)
+  private val berlinCenter = GeoPoint(52.5200, 13.4050)
+
+  private val docs = Chunk(
+    PlaceDocument("rome-a", "Rome", "active", romeCenter, Array(1.0f, 0.0f, 0.0f)),
+    PlaceDocument("rome-b", "Rome", "active", GeoPoint(41.91, 12.49), Array(0.94f, 0.30f, 0.0f)),
+    PlaceDocument("paris-a", "Paris", "active", parisCenter, Array(0.0f, 1.0f, 0.0f)),
+    PlaceDocument("berlin-a", "Berlin", "archived", berlinCenter, Array(-1.0f, 0.0f, 0.0f)),
+  )
+
+  private def withMap[A](
+    effect: GigaMap[String, PlaceDocument] => IO[GigaMapError, A]
+  ): ZIO[GigaMap[String, PlaceDocument], GigaMapError, A] =
+    ZIO.serviceWithZIO[GigaMap[String, PlaceDocument]](effect)
+
+  private val seed =
+    ZIO.foreachDiscard(docs)(doc => withMap(_.put(doc.id, doc)))
+
+  private def runWithLayer[A](
+    effect: ZIO[GigaMap[String, PlaceDocument], GigaMapError, A]
+  ): ZIO[Any, GigaMapError, A] =
+    ZIO.scoped {
+      layer.build.flatMap(env => effect.provideEnvironment(env))
+    }
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("Advanced indexing")(
+      test("nearest-neighbor queries return top results with expected similarity bounds") {
+        runWithLayer {
+          for
+          _       <- seed
+          results <- withMap(
+                       _.query(
+                         GigaMapQuery.VectorSearch(
+                           indexName = "embedding",
+                           vector = Chunk(1.0f, 0.0f, 0.0f),
+                           limit = 2,
+                           minScore = Some(0.8f),
+                         )
+                       )
+                     )
+          yield assertTrue(
+            results.length == 2,
+            results.headOption.exists(_.value.id == "rome-a"),
+            results.forall(_.score >= 0.8f),
+            results(0).score >= results(1).score,
+          )
+        }
+      },
+      test("radius queries return only entities inside the geographic filter") {
+        runWithLayer {
+          for
+          _       <- seed
+          results <- withMap(_.query(GigaMapQuery.SpatialRadius("location", romeCenter, radiusKilometers = 5.0)))
+          yield assertTrue(results.map(_.id).toSet == Set("rome-a", "rome-b"))
+        }
+      },
+      test("composite queries intersect bitmap, vector, and spatial predicates") {
+        runWithLayer {
+          for
+          _       <- seed
+          results <- withMap(
+                       _.query(
+                         GigaMapQuery.Composite(
+                           Chunk(
+                             GigaMapPredicate.ByIndex("city", "Rome"),
+                             GigaMapPredicate.ByIndex("status", "active"),
+                             GigaMapPredicate.VectorSearch(
+                               "embedding",
+                               Chunk(1.0f, 0.0f, 0.0f),
+                               limit = 3,
+                               minScore = Some(0.9f),
+                             ),
+                             GigaMapPredicate.SpatialRadius("location", romeCenter, radiusKilometers = 5.0),
+                           )
+                         )
+                       )
+                     )
+          yield assertTrue(results.map(_.id).toSet == Set("rome-a", "rome-b"))
+        }
+      },
+      test("new embeddings become queryable without a full rebuild") {
+        val madrid = PlaceDocument(
+          "madrid-a",
+          "Madrid",
+          "active",
+          GeoPoint(40.4168, -3.7038),
+          Array(1.0f, 0.02f, 0.0f),
+        )
+
+        runWithLayer {
+          for
+          _      <- seed
+          before <- withMap(_.query(GigaMapQuery.VectorSearch("embedding", Chunk(1.0f, 0.0f, 0.0f), limit = 3)))
+          _      <- withMap(_.put(madrid.id, madrid))
+          after  <- withMap(_.query(GigaMapQuery.VectorSearch("embedding", Chunk(1.0f, 0.0f, 0.0f), limit = 3)))
+          yield assertTrue(
+            !before.map(_.value.id).contains("madrid-a"),
+            after.map(_.value.id).contains("madrid-a"),
+          )
+        }
+      },
+      test("concurrent readers and index writers stay consistent under overlap") {
+        val lisbon = PlaceDocument(
+          "lisbon-a",
+          "Lisbon",
+          "active",
+          GeoPoint(38.7223, -9.1393),
+          Array(0.98f, 0.05f, 0.0f),
+        )
+
+        ZIO.scoped {
+          for
+            env     <- layer.build
+            _       <- ZIO.foreachDiscard(docs)(doc =>
+                         ZIO.serviceWithZIO[GigaMap[String, PlaceDocument]](_.put(doc.id, doc)).provideEnvironment(env)
+                       )
+            readers  = ZIO.foreachPar(1 to 24)(_ =>
+                         ZIO.serviceWithZIO[GigaMap[String, PlaceDocument]](
+                           _.query(
+                             GigaMapQuery.Composite(
+                               Chunk(
+                                 GigaMapPredicate.ByIndex("status", "active"),
+                                 GigaMapPredicate.VectorSearch(
+                                   "embedding",
+                                   Chunk(1.0f, 0.0f, 0.0f),
+                                   limit = 4,
+                                   minScore = Some(0.0f),
+                                 ),
+                               )
+                             )
+                           )
+                         ).provideEnvironment(env).either
+                       )
+            writer  <- ZIO.serviceWithZIO[GigaMap[String, PlaceDocument]](_.put(lisbon.id, lisbon)).provideEnvironment(env).fork
+            reads   <- readers
+            _       <- writer.join
+            results <- ZIO.serviceWithZIO[GigaMap[String, PlaceDocument]](
+                         _.query(GigaMapQuery.VectorSearch("embedding", Chunk(1.0f, 0.0f, 0.0f), limit = 5))
+                       ).provideEnvironment(env)
+          yield assertTrue(
+            reads.forall(_.isRight),
+            results.map(_.value.id).contains("lisbon-a"),
+          )
+        }
+      },
+    )

--- a/gigamap/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/GigaMapApiContractSpec.scala
+++ b/gigamap/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/gigamap/GigaMapApiContractSpec.scala
@@ -1,0 +1,33 @@
+package io.github.riccardomerolla.zio.eclipsestore.gigamap
+
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.error.PersistenceError
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.error.GigaMapError
+import io.github.riccardomerolla.zio.eclipsestore.gigamap.service.GigaMap
+
+object GigaMapApiContractSpec extends ZIOSpecDefault:
+
+  private val zioReturnType = classOf[ZIO[Any, Any, Any]]
+
+  private def publicDeclaredMethods(cls: Class[?]): List[Method] =
+    cls.getDeclaredMethods.toList.filter(m => Modifier.isPublic(m.getModifiers) && !m.isSynthetic)
+
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("GigaMap API contract")(
+      test("public methods return ZIO descriptions") {
+        val invalidMethods =
+          publicDeclaredMethods(classOf[GigaMap[Any, Any]].asInstanceOf[Class[?]]).filterNot { method =>
+            zioReturnType.isAssignableFrom(method.getReturnType)
+          }
+
+        assertTrue(invalidMethods.isEmpty)
+      },
+      test("public error ADT shares the PersistenceError contract") {
+        assertTrue(classOf[PersistenceError].isAssignableFrom(classOf[GigaMapError]))
+      },
+    )

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/Lazy.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/Lazy.scala
@@ -1,0 +1,118 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import zio.*
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** Scala-native lazy reference with effectful, memoized loading semantics. */
+final class Lazy[A] private (
+  private val serializedSnapshot: Option[A],
+  private val serializedUnavailableMessage: Option[String],
+  @transient private val loader: Option[() => IO[EclipseStoreError, A]],
+) extends Serializable:
+
+  @transient private lazy val stateRef: Ref.Synchronized[Lazy.State[A]] =
+    Lazy.makeStateRef(
+      serializedUnavailableMessage match
+        case Some(message) => Lazy.State.Unavailable(message)
+        case None          =>
+          serializedSnapshot match
+            case Some(value) => Lazy.State.Snapshot(value)
+            case None        =>
+              loader match
+                case Some(activeLoader) => Lazy.State.Unloaded(activeLoader)
+                case None               => Lazy.State.Unavailable("Lazy value was deserialized without an active store scope")
+    )
+
+  def load: IO[EclipseStoreError, A] =
+    ZIO.uninterruptibleMask { restore =>
+      Promise.make[EclipseStoreError, A].flatMap { promise =>
+        stateRef.modifyZIO {
+          case Lazy.State.Loaded(value)                  =>
+            ZIO.succeed((ZIO.succeed(value), Lazy.State.Loaded(value)))
+          case Lazy.State.Snapshot(value)                =>
+            ZIO.succeed((ZIO.succeed(value), Lazy.State.Loaded(value)))
+          case current @ Lazy.State.Loading(existing, _) =>
+            ZIO.succeed((restore(existing.await), current))
+          case current @ Lazy.State.Unavailable(message) =>
+            ZIO.succeed((ZIO.fail(EclipseStoreError.StoreNotOpen(message, None)), current))
+          case Lazy.State.Unloaded(activeLoader)         =>
+            val start = restore(activeLoader())
+              .exit
+              .flatMap {
+                case Exit.Success(value) =>
+                  stateRef.set(Lazy.State.Loaded(value)) *> promise.succeed(value).unit
+                case Exit.Failure(cause) =>
+                  val error = cause.failureOption.getOrElse(
+                    EclipseStoreError.ResourceError("Lazy load interrupted before completion", None)
+                  )
+                  stateRef.set(Lazy.State.Unloaded(activeLoader)) *> promise.fail(error).unit
+              }
+              .forkDaemon
+              .unit
+            ZIO.succeed((start *> restore(promise.await), Lazy.State.Loading(promise, activeLoader)))
+        }.flatten
+      }
+    }
+
+  val isLoaded: UIO[Boolean] =
+    stateRef.get.map {
+      case Lazy.State.Loaded(_) => true
+      case _                    => false
+    }
+
+  val isUnloaded: UIO[Boolean] =
+    isLoaded.map(!_)
+
+  def map[B](f: A => B): Lazy[B] =
+    unsafeState match
+      case Lazy.State.Loaded(value)      => Lazy.fromSnapshot(f(value))
+      case Lazy.State.Snapshot(value)    => Lazy.fromSnapshot(f(value))
+      case Lazy.State.Unavailable(error) => Lazy.unavailable(error)
+      case _                             => Lazy.fromZIO(load.map(f))
+
+  def flatMap[B](f: A => Lazy[B]): Lazy[B] =
+    unsafeState match
+      case Lazy.State.Loaded(value)      => f(value)
+      case Lazy.State.Snapshot(value)    => f(value)
+      case Lazy.State.Unavailable(error) => Lazy.unavailable(error)
+      case _                             => Lazy.fromZIO(load.flatMap(a => f(a).load))
+
+  def reset: UIO[Unit] =
+    stateRef.update {
+      case Lazy.State.Loaded(value) => Lazy.State.Snapshot(value)
+      case other                    => other
+    }
+
+  private def unsafeState: Lazy.State[A] =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(stateRef.get).getOrThrowFiberFailure()
+    }
+
+object Lazy:
+  def fromZIO[A](load: => IO[EclipseStoreError, A]): Lazy[A] =
+    new Lazy[A](None, None, Some(() => load))
+
+  def fromSnapshot[A](value: A): Lazy[A] =
+    new Lazy[A](Some(value), None, None)
+
+  def succeed[A](value: => A): Lazy[A] =
+    fromSnapshot(value)
+
+  def unavailable[A](message: String): Lazy[A] =
+    new Lazy[A](None, Some(message), None)
+
+  private def makeStateRef[A](state: State[A]): Ref.Synchronized[State[A]] =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run(Ref.Synchronized.make(state)).getOrThrowFiberFailure()
+    }
+
+  sealed private trait State[A]
+
+  private object State:
+    final case class Unloaded[A](loader: () => IO[EclipseStoreError, A]) extends State[A]
+    final case class Loading[A](promise: Promise[EclipseStoreError, A], loader: () => IO[EclipseStoreError, A])
+      extends State[A]
+    final case class Snapshot[A](value: A)                               extends State[A]
+    final case class Loaded[A](value: A)                                 extends State[A]
+    final case class Unavailable[A](message: String)                     extends State[A]

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala
@@ -10,13 +10,20 @@ sealed trait BackendConfig:
 
   def toStorageTarget: Either[EclipseStoreError, StorageTarget] =
     this match
-      case BackendConfig.FileSystem(path)   =>
+      case nativeLocal: BackendConfig.NativeLocal =>
+        Left(
+          EclipseStoreError.BackendError(
+            s"NativeLocal backend at ${nativeLocal.snapshotPath} does not map to an EclipseStore StorageTarget",
+            None,
+          )
+        )
+      case BackendConfig.FileSystem(path)         =>
         Right(StorageTarget.FileSystem(path))
-      case BackendConfig.MemoryMapped(path) =>
+      case BackendConfig.MemoryMapped(path)       =>
         Right(StorageTarget.MemoryMapped(path))
-      case BackendConfig.InMemory(prefix)   =>
+      case BackendConfig.InMemory(prefix)         =>
         Right(StorageTarget.InMemory(prefix))
-      case sqlite: BackendConfig.Sqlite     =>
+      case sqlite: BackendConfig.Sqlite           =>
         Right(
           StorageTarget.Sqlite(
             path = sqlite.path,
@@ -29,11 +36,11 @@ sealed trait BackendConfig:
             synchronousMode = sqlite.synchronousMode,
           )
         )
-      case s3: BackendConfig.S3             =>
+      case s3: BackendConfig.S3                   =>
         if s3.accessKey.isEmpty || s3.secretKey.isEmpty then
           Left(EclipseStoreError.AuthError(s"S3 backend '${s3.bucket}' requires accessKey and secretKey", None))
         else Left(EclipseStoreError.BackendError("S3 backend wiring is not implemented yet", None))
-      case azure: BackendConfig.AzureBlob   =>
+      case azure: BackendConfig.AzureBlob         =>
         if azure.connectionString.isEmpty && (azure.accountName.isEmpty || azure.accountKey.isEmpty) then
           Left(
             EclipseStoreError.AuthError(
@@ -42,11 +49,14 @@ sealed trait BackendConfig:
             )
           )
         else Left(EclipseStoreError.BackendError("Azure Blob backend wiring is not implemented yet", None))
-      case redis: BackendConfig.Redis       =>
+      case redis: BackendConfig.Redis             =>
         if redis.uri.trim.isEmpty then Left(EclipseStoreError.AuthError("Redis backend requires a non-empty URI", None))
         else Left(EclipseStoreError.BackendError("Redis backend wiring is not implemented yet", None))
 
 object BackendConfig:
+  final case class NativeLocal(snapshotPath: Path) extends BackendConfig:
+    override val name: String = "native-local"
+
   final case class FileSystem(path: Path) extends BackendConfig:
     override val name: String = "filesystem"
 

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala
@@ -1,0 +1,117 @@
+package io.github.riccardomerolla.zio.eclipsestore.config
+
+import java.nio.file.Path
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** Typed backend-selection surface for layer-based storage acquisition. */
+sealed trait BackendConfig:
+  def name: String
+
+  def toStorageTarget: Either[EclipseStoreError, StorageTarget] =
+    this match
+      case BackendConfig.FileSystem(path)   =>
+        Right(StorageTarget.FileSystem(path))
+      case BackendConfig.MemoryMapped(path) =>
+        Right(StorageTarget.MemoryMapped(path))
+      case BackendConfig.InMemory(prefix)   =>
+        Right(StorageTarget.InMemory(prefix))
+      case sqlite: BackendConfig.Sqlite     =>
+        Right(
+          StorageTarget.Sqlite(
+            path = sqlite.path,
+            storageName = sqlite.storageName,
+            connectionString = sqlite.connectionString,
+            busyTimeoutMs = sqlite.busyTimeoutMs,
+            cacheSizeKb = sqlite.cacheSizeKb,
+            pageSizeBytes = sqlite.pageSizeBytes,
+            journalMode = sqlite.journalMode,
+            synchronousMode = sqlite.synchronousMode,
+          )
+        )
+      case s3: BackendConfig.S3             =>
+        if s3.accessKey.isEmpty || s3.secretKey.isEmpty then
+          Left(EclipseStoreError.AuthError(s"S3 backend '${s3.bucket}' requires accessKey and secretKey", None))
+        else Left(EclipseStoreError.BackendError("S3 backend wiring is not implemented yet", None))
+      case azure: BackendConfig.AzureBlob   =>
+        if azure.connectionString.isEmpty && (azure.accountName.isEmpty || azure.accountKey.isEmpty) then
+          Left(
+            EclipseStoreError.AuthError(
+              s"Azure backend '${azure.container}' requires connectionString or accountName/accountKey",
+              None,
+            )
+          )
+        else Left(EclipseStoreError.BackendError("Azure Blob backend wiring is not implemented yet", None))
+      case redis: BackendConfig.Redis       =>
+        if redis.uri.trim.isEmpty then Left(EclipseStoreError.AuthError("Redis backend requires a non-empty URI", None))
+        else Left(EclipseStoreError.BackendError("Redis backend wiring is not implemented yet", None))
+
+object BackendConfig:
+  final case class FileSystem(path: Path) extends BackendConfig:
+    override val name: String = "filesystem"
+
+  final case class MemoryMapped(path: Path) extends BackendConfig:
+    override val name: String = "memory-mapped"
+
+  final case class InMemory(prefix: String = "eclipsestore") extends BackendConfig:
+    override val name: String = "in-memory"
+
+  final case class Sqlite(
+    path: Path,
+    storageName: String = "eclipsestore.db",
+    connectionString: Option[String] = None,
+    busyTimeoutMs: Option[Int] = None,
+    cacheSizeKb: Option[Int] = None,
+    pageSizeBytes: Option[Int] = None,
+    journalMode: Option[String] = None,
+    synchronousMode: Option[String] = None,
+  ) extends BackendConfig:
+    override val name: String = "sqlite"
+
+  final case class S3(
+    bucket: String,
+    prefix: Option[String] = None,
+    region: Option[String] = None,
+    accessKey: Option[String] = None,
+    secretKey: Option[String] = None,
+  ) extends BackendConfig:
+    override val name: String = "s3"
+
+  final case class AzureBlob(
+    container: String,
+    prefix: Option[String] = None,
+    connectionString: Option[String] = None,
+    accountName: Option[String] = None,
+    accountKey: Option[String] = None,
+  ) extends BackendConfig:
+    override val name: String = "azure-blob"
+
+  final case class Redis(
+    uri: String,
+    namespace: Option[String] = None,
+  ) extends BackendConfig:
+    override val name: String = "redis"
+
+  def fromStorageTarget(target: StorageTarget): Either[EclipseStoreError, BackendConfig] =
+    target match
+      case StorageTarget.FileSystem(path)   =>
+        Right(FileSystem(path))
+      case StorageTarget.MemoryMapped(path) =>
+        Right(MemoryMapped(path))
+      case StorageTarget.InMemory(prefix)   =>
+        Right(InMemory(prefix))
+      case sqlite: StorageTarget.Sqlite     =>
+        Right(
+          Sqlite(
+            path = sqlite.path,
+            storageName = sqlite.storageName,
+            connectionString = sqlite.connectionString,
+            busyTimeoutMs = sqlite.busyTimeoutMs,
+            cacheSizeKb = sqlite.cacheSizeKb,
+            pageSizeBytes = sqlite.pageSizeBytes,
+            journalMode = sqlite.journalMode,
+            synchronousMode = sqlite.synchronousMode,
+          )
+        )
+      case _: StorageTarget.Custom          =>
+        Left(EclipseStoreError.BackendError("Custom storage targets cannot be decoded into BackendConfig", None))

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/BackendConfig.scala
@@ -54,7 +54,8 @@ sealed trait BackendConfig:
         else Left(EclipseStoreError.BackendError("Redis backend wiring is not implemented yet", None))
 
 object BackendConfig:
-  final case class NativeLocal(snapshotPath: Path) extends BackendConfig:
+  final case class NativeLocal(snapshotPath: Path, serde: NativeLocalSerde = NativeLocalSerde.Json)
+    extends BackendConfig:
     override val name: String = "native-local"
 
   final case class FileSystem(path: Path) extends BackendConfig:

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/EclipseStoreConfigZIO.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/EclipseStoreConfigZIO.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.{ Config as HoconConfig, ConfigFactory }
 
 object EclipseStoreConfigZIO:
 
-  final private case class NativeLocalInput(snapshotPath: Path)
+  final private case class NativeLocalInput(snapshotPath: Path, serde: Option[String])
 
   final private case class FileSystemInput(path: Path)
 
@@ -132,7 +132,13 @@ object EclipseStoreConfigZIO:
 
     if hocon.hasPath(s"$backendBase.nativeLocal.snapshotPath") then
       configInput.backend.flatMap(_.nativeLocal) match
-        case Some(nativeLocal) => BackendConfig.NativeLocal(nativeLocal.snapshotPath)
+        case Some(nativeLocal) =>
+          BackendConfig.NativeLocal(
+            nativeLocal.snapshotPath,
+            nativeLocal.serde
+              .map(resolveNativeLocalSerde)
+              .getOrElse(NativeLocalSerde.Json),
+          )
         case None              => defaultBackendConfig
     else if hocon.hasPath(s"$backendBase.fileSystem.path") then
       configInput.backend.flatMap(_.fileSystem) match
@@ -164,6 +170,10 @@ object EclipseStoreConfigZIO:
       BackendConfig
         .fromStorageTarget(resolveStorageTarget(hocon))
         .getOrElse(defaultBackendConfig)
+
+  private def resolveNativeLocalSerde(value: String): NativeLocalSerde =
+    if value.equalsIgnoreCase("protobuf") || value.equalsIgnoreCase("proto") then NativeLocalSerde.Protobuf
+    else NativeLocalSerde.Json
 
   private def loadConfig(provider: zio.ConfigProvider, hocon: HoconConfig)
     : ZIO[Any, zio.Config.Error, EclipseStoreConfig] =

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/EclipseStoreConfigZIO.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/EclipseStoreConfigZIO.scala
@@ -10,6 +10,33 @@ import com.typesafe.config.{ Config as HoconConfig, ConfigFactory }
 
 object EclipseStoreConfigZIO:
 
+  final private case class NativeLocalInput(snapshotPath: Path)
+
+  final private case class FileSystemInput(path: Path)
+
+  final private case class MemoryMappedInput(path: Path)
+
+  final private case class InMemoryInput(prefix: Option[String])
+
+  final private case class SqliteInput(
+    path: Path,
+    storageName: Option[String],
+    connectionString: Option[String],
+    busyTimeoutMs: Option[Int],
+    cacheSizeKb: Option[Int],
+    pageSizeBytes: Option[Int],
+    journalMode: Option[String],
+    synchronousMode: Option[String],
+  )
+
+  final private case class BackendInput(
+    nativeLocal: Option[NativeLocalInput],
+    fileSystem: Option[FileSystemInput],
+    memoryMapped: Option[MemoryMappedInput],
+    inMemory: Option[InMemoryInput],
+    sqlite: Option[SqliteInput],
+  )
+
   final private case class ConfigInput(
     maxParallelism: Option[Int],
     batchSize: Option[Int],
@@ -22,6 +49,7 @@ object EclipseStoreConfigZIO:
     backupDeletionDirectory: Option[Path],
     backupExternalProperties: Option[Map[String, String]],
     autoRegisterSchemaHandlers: Option[Boolean],
+    backend: Option[BackendInput],
   )
 
   private given zio.Config[Path] =
@@ -62,6 +90,9 @@ object EclipseStoreConfigZIO:
   private val config: zio.Config[ConfigInput] =
     deriveConfig[ConfigInput].nested("eclipsestore")
 
+  private val defaultBackendConfig: BackendConfig =
+    BackendConfig.InMemory("eclipsestore")
+
   private def resolveStorageTarget(config: HoconConfig): StorageTarget =
     val base   = "eclipsestore.storageTarget"
     val sqlite = s"$base.sqlite"
@@ -96,6 +127,44 @@ object EclipseStoreConfigZIO:
       val prefix = if config.hasPath(inMem) then config.getString(inMem) else "eclipsestore"
       StorageTarget.InMemory(prefix)
 
+  private def resolveBackendConfig(configInput: ConfigInput, hocon: HoconConfig): BackendConfig =
+    val backendBase = "eclipsestore.backend"
+
+    if hocon.hasPath(s"$backendBase.nativeLocal.snapshotPath") then
+      configInput.backend.flatMap(_.nativeLocal) match
+        case Some(nativeLocal) => BackendConfig.NativeLocal(nativeLocal.snapshotPath)
+        case None              => defaultBackendConfig
+    else if hocon.hasPath(s"$backendBase.fileSystem.path") then
+      configInput.backend.flatMap(_.fileSystem) match
+        case Some(fileSystem) => BackendConfig.FileSystem(fileSystem.path)
+        case None             => defaultBackendConfig
+    else if hocon.hasPath(s"$backendBase.memoryMapped.path") then
+      configInput.backend.flatMap(_.memoryMapped) match
+        case Some(memoryMapped) => BackendConfig.MemoryMapped(memoryMapped.path)
+        case None               => defaultBackendConfig
+    else if hocon.hasPath(s"$backendBase.sqlite.path") then
+      configInput.backend.flatMap(_.sqlite) match
+        case Some(sqlite) =>
+          BackendConfig.Sqlite(
+            path = sqlite.path,
+            storageName = sqlite.storageName.getOrElse("eclipsestore.db"),
+            connectionString = sqlite.connectionString,
+            busyTimeoutMs = sqlite.busyTimeoutMs,
+            cacheSizeKb = sqlite.cacheSizeKb,
+            pageSizeBytes = sqlite.pageSizeBytes,
+            journalMode = sqlite.journalMode,
+            synchronousMode = sqlite.synchronousMode,
+          )
+        case None         => defaultBackendConfig
+    else if hocon.hasPath(s"$backendBase.inMemory") then
+      configInput.backend.flatMap(_.inMemory) match
+        case Some(inMemory) => BackendConfig.InMemory(inMemory.prefix.getOrElse("eclipsestore"))
+        case None           => BackendConfig.InMemory("eclipsestore")
+    else
+      BackendConfig
+        .fromStorageTarget(resolveStorageTarget(hocon))
+        .getOrElse(defaultBackendConfig)
+
   private def loadConfig(provider: zio.ConfigProvider, hocon: HoconConfig)
     : ZIO[Any, zio.Config.Error, EclipseStoreConfig] =
     for in <- provider.load(config)
@@ -118,12 +187,28 @@ object EclipseStoreConfigZIO:
       eagerStoringEvaluator = defaults.eagerStoringEvaluator,
     )
 
+  private def loadBackendConfig(provider: zio.ConfigProvider, hocon: HoconConfig)
+    : ZIO[Any, zio.Config.Error, BackendConfig] =
+    for in <- provider.load(config)
+    yield resolveBackendConfig(in, hocon)
+
   val fromResourcePath: ZLayer[Any, zio.Config.Error, EclipseStoreConfig] =
     ZLayer.fromZIO(loadConfig(TypesafeConfigProvider.fromResourcePath(), ConfigFactory.load()))
+
+  val backendFromResourcePath: ZLayer[Any, zio.Config.Error, BackendConfig] =
+    ZLayer.fromZIO(loadBackendConfig(TypesafeConfigProvider.fromResourcePath(), ConfigFactory.load()))
 
   def fromFile(path: Path): ZLayer[Any, zio.Config.Error, EclipseStoreConfig] =
     ZLayer.fromZIO(
       loadConfig(
+        TypesafeConfigProvider.fromHoconFile(path.toFile),
+        ConfigFactory.parseFile(path.toFile).resolve(),
+      )
+    )
+
+  def backendFromFile(path: Path): ZLayer[Any, zio.Config.Error, BackendConfig] =
+    ZLayer.fromZIO(
+      loadBackendConfig(
         TypesafeConfigProvider.fromHoconFile(path.toFile),
         ConfigFactory.parseFile(path.toFile).resolve(),
       )

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/NativeLocalSerde.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/config/NativeLocalSerde.scala
@@ -1,0 +1,5 @@
+package io.github.riccardomerolla.zio.eclipsestore.config
+
+enum NativeLocalSerde:
+  case Json
+  case Protobuf

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/EclipseStoreError.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/EclipseStoreError.scala
@@ -7,3 +7,4 @@ enum EclipseStoreError extends PersistenceError:
   case ResourceError(message: String, cause: Option[Throwable] = None)
   case BackendError(message: String, cause: Option[Throwable] = None)
   case AuthError(message: String, cause: Option[Throwable] = None)
+  case StoreNotOpen(message: String, cause: Option[Throwable] = None)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/EclipseStoreError.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/EclipseStoreError.scala
@@ -5,3 +5,5 @@ enum EclipseStoreError extends PersistenceError:
   case QueryError(message: String, cause: Option[Throwable] = None)
   case InitializationError(message: String, cause: Option[Throwable] = None)
   case ResourceError(message: String, cause: Option[Throwable] = None)
+  case BackendError(message: String, cause: Option[Throwable] = None)
+  case AuthError(message: String, cause: Option[Throwable] = None)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/EclipseStoreError.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/EclipseStoreError.scala
@@ -1,6 +1,6 @@
 package io.github.riccardomerolla.zio.eclipsestore.error
 
-enum EclipseStoreError:
+enum EclipseStoreError extends PersistenceError:
   case StorageError(message: String, cause: Option[Throwable] = None)
   case QueryError(message: String, cause: Option[Throwable] = None)
   case InitializationError(message: String, cause: Option[Throwable] = None)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/EclipseStoreError.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/EclipseStoreError.scala
@@ -8,3 +8,4 @@ enum EclipseStoreError extends PersistenceError:
   case BackendError(message: String, cause: Option[Throwable] = None)
   case AuthError(message: String, cause: Option[Throwable] = None)
   case StoreNotOpen(message: String, cause: Option[Throwable] = None)
+  case ConflictError(message: String, cause: Option[Throwable] = None)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/EclipseStoreError.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/EclipseStoreError.scala
@@ -9,3 +9,5 @@ enum EclipseStoreError extends PersistenceError:
   case AuthError(message: String, cause: Option[Throwable] = None)
   case StoreNotOpen(message: String, cause: Option[Throwable] = None)
   case ConflictError(message: String, cause: Option[Throwable] = None)
+  case MigrationError(message: String, cause: Option[Throwable] = None)
+  case IncompatibleSchemaError(message: String, cause: Option[Throwable] = None)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/PersistenceError.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/error/PersistenceError.scala
@@ -1,0 +1,8 @@
+package io.github.riccardomerolla.zio.eclipsestore.error
+
+/** Marker trait for typed persistence-domain failures exposed by the public API.
+  *
+  * Concrete subsystems may refine this contract with narrower ADTs, but public storage-facing error channels should
+  * remain inside this hierarchy instead of leaking raw `Throwable` values.
+  */
+trait PersistenceError extends Product with Serializable

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala
@@ -106,7 +106,10 @@ object TodoNativeLocalApp extends ZIOAppDefault:
         second   <- TodoService.add("verify restart semantics")
         _        <- TodoService.complete(first.id)
         reloaded <- TodoService.checkpointAndReload
-        _        <- ZIO.logInfo(s"Reloaded ${reloaded.size} todos: ${reloaded.map(todo => s"${todo.title}:${todo.completed}").mkString(", ")}")
+        _        <-
+          ZIO.logInfo(
+            s"Reloaded ${reloaded.size} todos: ${reloaded.map(todo => s"${todo.title}:${todo.completed}").mkString(", ")}"
+          )
         _        <- ZIO.logInfo(s"Snapshot file: $snapshotPath")
         _        <- ZIO.logDebug(
                       s"Second todo still pending: ${reloaded.exists(todo => todo.id == second.id && !todo.completed)}"
@@ -127,9 +130,10 @@ object TodoNativeLocalProtobufApp extends ZIOAppDefault:
         second   <- TodoService.add("verify protobuf restart semantics")
         _        <- TodoService.complete(first.id)
         reloaded <- TodoService.checkpointAndReload
-        _        <- ZIO.logInfo(
-                      s"Reloaded protobuf ${reloaded.size} todos: ${reloaded.map(todo => s"${todo.title}:${todo.completed}").mkString(", ")}"
-                    )
+        _        <-
+          ZIO.logInfo(
+            s"Reloaded protobuf ${reloaded.size} todos: ${reloaded.map(todo => s"${todo.title}:${todo.completed}").mkString(", ")}"
+          )
         _        <- ZIO.logInfo(s"Snapshot file: $snapshotPath")
         _        <-
           ZIO.logDebug(

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala
@@ -1,0 +1,115 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal
+
+import java.nio.file.{ Path, Paths }
+import java.util.UUID
+
+import zio.*
+import zio.schema.{ DeriveSchema, Schema }
+
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.{ ObjectStore, StorageBackend, StorageOps }
+
+final case class TodoId(value: UUID)
+
+final case class TodoItem(
+  id: TodoId,
+  title: String,
+  completed: Boolean,
+)
+
+final case class TodoRoot(items: Chunk[TodoItem])
+
+object TodoId:
+  given Schema[TodoId] = DeriveSchema.gen[TodoId]
+
+object TodoItem:
+  given Schema[TodoItem] = DeriveSchema.gen[TodoItem]
+
+object TodoRoot:
+  given Schema[TodoRoot] = DeriveSchema.gen[TodoRoot]
+
+  val descriptor: RootDescriptor[TodoRoot] =
+    RootDescriptor.fromSchema(
+      id = "todo-native-local-root",
+      initializer = () => TodoRoot(Chunk.empty),
+    )
+
+trait TodoService:
+  def add(title: String): IO[EclipseStoreError, TodoItem]
+  def complete(id: TodoId): IO[EclipseStoreError, TodoItem]
+  def list: IO[EclipseStoreError, Chunk[TodoItem]]
+  def checkpointAndReload: IO[EclipseStoreError, Chunk[TodoItem]]
+
+final case class TodoServiceLive(
+  store: ObjectStore[TodoRoot],
+  ops: StorageOps[TodoRoot],
+) extends TodoService:
+  override def add(title: String): IO[EclipseStoreError, TodoItem] =
+    store.modify { root =>
+      val item = TodoItem(TodoId(UUID.randomUUID()), title, completed = false)
+      ZIO.succeed((item, root.copy(items = root.items :+ item)))
+    }
+
+  override def complete(id: TodoId): IO[EclipseStoreError, TodoItem] =
+    store.modify { root =>
+      root.items.indexWhere(_.id == id) match
+        case -1    =>
+          ZIO.fail(EclipseStoreError.QueryError(s"Todo ${id.value} not found", None))
+        case index =>
+          val updated = root.items(index).copy(completed = true)
+          ZIO.succeed(
+            (
+              updated,
+              root.copy(items = root.items.updated(index, updated)),
+            )
+          )
+    }
+
+  override def list: IO[EclipseStoreError, Chunk[TodoItem]] =
+    store.load.map(_.items)
+
+  override def checkpointAndReload: IO[EclipseStoreError, Chunk[TodoItem]] =
+    ops.checkpoint *> ops.restart *> list
+
+object TodoService:
+  def add(title: String): ZIO[TodoService, EclipseStoreError, TodoItem] =
+    ZIO.serviceWithZIO[TodoService](_.add(title))
+
+  def complete(id: TodoId): ZIO[TodoService, EclipseStoreError, TodoItem] =
+    ZIO.serviceWithZIO[TodoService](_.complete(id))
+
+  val list: ZIO[TodoService, EclipseStoreError, Chunk[TodoItem]] =
+    ZIO.serviceWithZIO[TodoService](_.list)
+
+  val checkpointAndReload: ZIO[TodoService, EclipseStoreError, Chunk[TodoItem]] =
+    ZIO.serviceWithZIO[TodoService](_.checkpointAndReload)
+
+  def layer(snapshotPath: Path): ZLayer[Any, EclipseStoreError, TodoService] =
+    ZLayer.make[TodoService](
+      ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath)),
+      StorageBackend.rootServices(TodoRoot.descriptor),
+      ZLayer.fromFunction(TodoServiceLive.apply),
+    )
+
+object TodoNativeLocalApp extends ZIOAppDefault:
+  private val snapshotPath = Paths.get("todo-native-local.snapshot.json")
+
+  override def run: URIO[ZIOAppArgs & Scope, Any] =
+    val program =
+      for
+        first    <- TodoService.add("write snapshot guide")
+        second   <- TodoService.add("verify restart semantics")
+        _        <- TodoService.complete(first.id)
+        reloaded <- TodoService.checkpointAndReload
+        _        <- ZIO.logInfo(s"Reloaded todos: ${reloaded.map(todo => s"${todo.title}:${todo.completed}").mkString(", ")}")
+        _        <- ZIO.logInfo(s"Snapshot file: $snapshotPath")
+        _        <- ZIO.logDebug(
+                      s"Second todo still pending: ${reloaded.exists(todo => todo.id == second.id && !todo.completed)}"
+                    )
+      yield ()
+
+    program
+      .provide(TodoService.layer(snapshotPath))
+      .catchAll(error => ZIO.logError(error.toString))

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala
@@ -106,7 +106,7 @@ object TodoNativeLocalApp extends ZIOAppDefault:
         second   <- TodoService.add("verify restart semantics")
         _        <- TodoService.complete(first.id)
         reloaded <- TodoService.checkpointAndReload
-        _        <- ZIO.logInfo(s"Reloaded todos: ${reloaded.map(todo => s"${todo.title}:${todo.completed}").mkString(", ")}")
+        _        <- ZIO.logInfo(s"Reloaded ${reloaded.size} todos: ${reloaded.map(todo => s"${todo.title}:${todo.completed}").mkString(", ")}")
         _        <- ZIO.logInfo(s"Snapshot file: $snapshotPath")
         _        <- ZIO.logDebug(
                       s"Second todo still pending: ${reloaded.exists(todo => todo.id == second.id && !todo.completed)}"
@@ -128,7 +128,7 @@ object TodoNativeLocalProtobufApp extends ZIOAppDefault:
         _        <- TodoService.complete(first.id)
         reloaded <- TodoService.checkpointAndReload
         _        <- ZIO.logInfo(
-                      s"Reloaded protobuf todos: ${reloaded.map(todo => s"${todo.title}:${todo.completed}").mkString(", ")}"
+                      s"Reloaded protobuf ${reloaded.size} todos: ${reloaded.map(todo => s"${todo.title}:${todo.completed}").mkString(", ")}"
                     )
         _        <- ZIO.logInfo(s"Snapshot file: $snapshotPath")
         _        <-

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalApp.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import zio.*
 import zio.schema.{ DeriveSchema, Schema }
 
-import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, NativeLocalSerde }
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 import io.github.riccardomerolla.zio.eclipsestore.service.{ ObjectStore, StorageBackend, StorageOps }
@@ -86,9 +86,12 @@ object TodoService:
   val checkpointAndReload: ZIO[TodoService, EclipseStoreError, Chunk[TodoItem]] =
     ZIO.serviceWithZIO[TodoService](_.checkpointAndReload)
 
-  def layer(snapshotPath: Path): ZLayer[Any, EclipseStoreError, TodoService] =
+  def layer(
+    snapshotPath: Path,
+    serde: NativeLocalSerde = NativeLocalSerde.Json,
+  ): ZLayer[Any, EclipseStoreError, TodoService] =
     ZLayer.make[TodoService](
-      ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath)),
+      ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath, serde)),
       StorageBackend.rootServices(TodoRoot.descriptor),
       ZLayer.fromFunction(TodoServiceLive.apply),
     )
@@ -112,4 +115,28 @@ object TodoNativeLocalApp extends ZIOAppDefault:
 
     program
       .provide(TodoService.layer(snapshotPath))
+      .catchAll(error => ZIO.logError(error.toString))
+
+object TodoNativeLocalProtobufApp extends ZIOAppDefault:
+  private val snapshotPath = Paths.get("todo-native-local.snapshot.pb")
+
+  override def run: URIO[ZIOAppArgs & Scope, Any] =
+    val program =
+      for
+        first    <- TodoService.add("write protobuf snapshot guide")
+        second   <- TodoService.add("verify protobuf restart semantics")
+        _        <- TodoService.complete(first.id)
+        reloaded <- TodoService.checkpointAndReload
+        _        <- ZIO.logInfo(
+                      s"Reloaded protobuf todos: ${reloaded.map(todo => s"${todo.title}:${todo.completed}").mkString(", ")}"
+                    )
+        _        <- ZIO.logInfo(s"Snapshot file: $snapshotPath")
+        _        <-
+          ZIO.logDebug(
+            s"Second protobuf todo still pending: ${reloaded.exists(todo => todo.id == second.id && !todo.completed)}"
+          )
+      yield ()
+
+    program
+      .provide(TodoService.layer(snapshotPath, NativeLocalSerde.Protobuf))
       .catchAll(error => ZIO.logError(error.toString))

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalEventSourcingApp.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalEventSourcingApp.scala
@@ -1,0 +1,287 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal
+
+import java.nio.file.{ Path, Paths }
+
+import zio.*
+import zio.schema.{ DeriveSchema, Schema }
+
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, NativeLocalSerde }
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.{ ObjectStore, StorageBackend, StorageOps }
+
+enum TodoEventCommand:
+  case AddTodo(id: TodoId, title: String, priority: String)
+  case CompleteTodo(id: TodoId)
+
+object TodoEventCommand:
+  given Schema[TodoEventCommand] = DeriveSchema.gen[TodoEventCommand]
+
+enum TodoEvent:
+  case TodoAdded(id: TodoId, title: String, priority: String)
+  case TodoCompleted(id: TodoId)
+
+object TodoEvent:
+  given Schema[TodoEvent] = DeriveSchema.gen[TodoEvent]
+
+final case class TodoEventRecord(
+  sequence: Long,
+  event: TodoEvent,
+)
+
+object TodoEventRecord:
+  given Schema[TodoEventRecord] = DeriveSchema.gen[TodoEventRecord]
+
+final case class TodoProjectionItem(
+  id: TodoId,
+  title: String,
+  completed: Boolean,
+  priority: String,
+)
+
+object TodoProjectionItem:
+  given Schema[TodoProjectionItem] = DeriveSchema.gen[TodoProjectionItem]
+
+final case class TodoProjection(items: Chunk[TodoProjectionItem])
+
+object TodoProjection:
+  given Schema[TodoProjection] = DeriveSchema.gen[TodoProjection]
+
+  val empty: TodoProjection =
+    TodoProjection(Chunk.empty)
+
+final case class TodoEventJournalRoot(
+  snapshot: TodoProjection,
+  journal: Chunk[TodoEventRecord],
+  nextSequence: Long,
+)
+
+object TodoEventJournalRoot:
+  given Schema[TodoEventJournalRoot] = DeriveSchema.gen[TodoEventJournalRoot]
+
+  val empty: TodoEventJournalRoot =
+    TodoEventJournalRoot(
+      snapshot = TodoProjection.empty,
+      journal = Chunk.empty,
+      nextSequence = 1L,
+    )
+
+  val descriptor: RootDescriptor[TodoEventJournalRoot] =
+    RootDescriptor.fromSchema(
+      id = "todo-native-local-event-sourcing-root",
+      initializer = () => empty,
+    )
+
+enum TodoEventSourcingError:
+  case EmptyTitle
+  case EmptyPriority
+  case TodoNotFound(id: TodoId)
+  case TodoAlreadyCompleted(id: TodoId)
+  case SnapshotDrift(expected: TodoProjection, replayed: TodoProjection)
+
+  def message: String =
+    this match
+      case EmptyTitle                        => "Todo title must not be empty"
+      case EmptyPriority                     => "Todo priority must not be empty"
+      case TodoNotFound(id)                  => s"Todo ${id.value} not found"
+      case TodoAlreadyCompleted(id)          => s"Todo ${id.value} is already completed"
+      case SnapshotDrift(expected, replayed) =>
+        s"Stored snapshot drift detected. Expected=${expected.items.size} replayed=${replayed.items.size}"
+
+object TodoEventSourcing:
+  def replay(journal: Chunk[TodoEventRecord]): TodoProjection =
+    journal.foldLeft(TodoProjection.empty) { (state, record) =>
+      evolve(state, record.event)
+    }
+
+  def decide(
+    state: TodoProjection,
+    command: TodoEventCommand,
+  ): Either[TodoEventSourcingError, Chunk[TodoEvent]] =
+    command match
+      case TodoEventCommand.AddTodo(_, title, _) if title.trim.isEmpty           =>
+        Left(TodoEventSourcingError.EmptyTitle)
+      case TodoEventCommand.AddTodo(_, title, priority) if priority.trim.isEmpty =>
+        Left(TodoEventSourcingError.EmptyPriority)
+      case TodoEventCommand.AddTodo(id, title, priority)                         =>
+        Right(
+          Chunk.single(
+            TodoEvent.TodoAdded(
+              id = id,
+              title = title.trim,
+              priority = priority.trim,
+            )
+          )
+        )
+      case TodoEventCommand.CompleteTodo(id)                                     =>
+        state.items.find(_.id == id) match
+          case None                         => Left(TodoEventSourcingError.TodoNotFound(id))
+          case Some(todo) if todo.completed =>
+            Left(TodoEventSourcingError.TodoAlreadyCompleted(id))
+          case Some(_)                      =>
+            Right(Chunk.single(TodoEvent.TodoCompleted(id)))
+
+  def runCommand(
+    root: TodoEventJournalRoot,
+    command: TodoEventCommand,
+  ): Either[TodoEventSourcingError, (Chunk[TodoEventRecord], TodoEventJournalRoot)] =
+    for
+      _      <- validate(root)
+      events <- decide(root.snapshot, command)
+    yield
+      val records      =
+        events.zipWithIndex.map {
+          case (event, index) =>
+            TodoEventRecord(root.nextSequence + index.toLong, event)
+        }
+      val nextSnapshot =
+        records.foldLeft(root.snapshot) { (state, record) =>
+          evolve(state, record.event)
+        }
+      (
+        records,
+        root.copy(
+          snapshot = nextSnapshot,
+          journal = root.journal ++ records,
+          nextSequence = root.nextSequence + records.size.toLong,
+        ),
+      )
+
+  def validate(root: TodoEventJournalRoot): Either[TodoEventSourcingError, Unit] =
+    val replayed = replay(root.journal)
+    Either.cond(
+      replayed == root.snapshot,
+      (),
+      TodoEventSourcingError.SnapshotDrift(root.snapshot, replayed),
+    )
+
+  private def evolve(
+    state: TodoProjection,
+    event: TodoEvent,
+  ): TodoProjection =
+    event match
+      case TodoEvent.TodoAdded(id, title, priority) =>
+        state.copy(
+          items = state.items :+ TodoProjectionItem(id, title, completed = false, priority)
+        )
+      case TodoEvent.TodoCompleted(id)              =>
+        state.copy(
+          items = state.items.map { item =>
+            if item.id == id then item.copy(completed = true) else item
+          }
+        )
+
+trait TodoEventSourcedService:
+  def add(title: String, priority: String): IO[EclipseStoreError, TodoProjectionItem]
+  def complete(id: TodoId): IO[EclipseStoreError, TodoProjectionItem]
+  def process(command: TodoEventCommand): IO[EclipseStoreError, Chunk[TodoEventRecord]]
+  def currentState: IO[EclipseStoreError, TodoProjection]
+  def journal: IO[EclipseStoreError, Chunk[TodoEventRecord]]
+  def replayedState: IO[EclipseStoreError, TodoProjection]
+  def checkpointAndReload: IO[EclipseStoreError, TodoEventJournalRoot]
+
+final case class TodoEventSourcedServiceLive(
+  store: ObjectStore[TodoEventJournalRoot],
+  ops: StorageOps[TodoEventJournalRoot],
+) extends TodoEventSourcedService:
+  override def add(title: String, priority: String): IO[EclipseStoreError, TodoProjectionItem] =
+    for
+      id      <- Random.nextUUID.map(TodoId.apply)
+      records <- process(TodoEventCommand.AddTodo(id, title, priority))
+      added   <- ZIO
+                   .fromOption(
+                     records.collectFirst {
+                       case TodoEventRecord(_, TodoEvent.TodoAdded(todoId, todoTitle, todoPriority)) =>
+                         TodoProjectionItem(todoId, todoTitle, completed = false, todoPriority)
+                     }
+                   )
+                   .orElseFail(EclipseStoreError.QueryError("Expected TodoAdded event after add command", None))
+    yield added
+
+  override def complete(id: TodoId): IO[EclipseStoreError, TodoProjectionItem] =
+    process(TodoEventCommand.CompleteTodo(id)) *> currentState.flatMap { snapshot =>
+      ZIO
+        .fromOption(snapshot.items.find(_.id == id))
+        .orElseFail(EclipseStoreError.QueryError(s"Todo ${id.value} not found after completion", None))
+    }
+
+  override def process(command: TodoEventCommand): IO[EclipseStoreError, Chunk[TodoEventRecord]] =
+    for
+      records <- store.modify { root =>
+                   ZIO.fromEither(TodoEventSourcing.runCommand(root, command)).mapError(toStoreError)
+                 }
+      _       <- ops.checkpoint
+    yield records
+
+  override def currentState: IO[EclipseStoreError, TodoProjection] =
+    store.load.map(_.snapshot)
+
+  override def journal: IO[EclipseStoreError, Chunk[TodoEventRecord]] =
+    store.load.map(_.journal)
+
+  override def replayedState: IO[EclipseStoreError, TodoProjection] =
+    store.load.flatMap { root =>
+      ZIO.fromEither(
+        TodoEventSourcing.validate(root).map(_ => TodoEventSourcing.replay(root.journal))
+      ).mapError(toStoreError)
+    }
+
+  override def checkpointAndReload: IO[EclipseStoreError, TodoEventJournalRoot] =
+    ops.checkpoint *> ops.restart *> store.load
+
+  private def toStoreError(error: TodoEventSourcingError): EclipseStoreError =
+    EclipseStoreError.QueryError(error.message, None)
+
+object TodoEventSourcedService:
+  def add(title: String, priority: String): ZIO[TodoEventSourcedService, EclipseStoreError, TodoProjectionItem] =
+    ZIO.serviceWithZIO[TodoEventSourcedService](_.add(title, priority))
+
+  def complete(id: TodoId): ZIO[TodoEventSourcedService, EclipseStoreError, TodoProjectionItem] =
+    ZIO.serviceWithZIO[TodoEventSourcedService](_.complete(id))
+
+  def process(command: TodoEventCommand): ZIO[TodoEventSourcedService, EclipseStoreError, Chunk[TodoEventRecord]] =
+    ZIO.serviceWithZIO[TodoEventSourcedService](_.process(command))
+
+  val currentState: ZIO[TodoEventSourcedService, EclipseStoreError, TodoProjection] =
+    ZIO.serviceWithZIO[TodoEventSourcedService](_.currentState)
+
+  val journal: ZIO[TodoEventSourcedService, EclipseStoreError, Chunk[TodoEventRecord]] =
+    ZIO.serviceWithZIO[TodoEventSourcedService](_.journal)
+
+  val replayedState: ZIO[TodoEventSourcedService, EclipseStoreError, TodoProjection] =
+    ZIO.serviceWithZIO[TodoEventSourcedService](_.replayedState)
+
+  val checkpointAndReload: ZIO[TodoEventSourcedService, EclipseStoreError, TodoEventJournalRoot] =
+    ZIO.serviceWithZIO[TodoEventSourcedService](_.checkpointAndReload)
+
+  def layer(
+    snapshotPath: Path,
+    serde: NativeLocalSerde = NativeLocalSerde.Json,
+  ): ZLayer[Any, EclipseStoreError, TodoEventSourcedService] =
+    ZLayer.make[TodoEventSourcedService](
+      ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath, serde)),
+      StorageBackend.rootServices(TodoEventJournalRoot.descriptor),
+      ZLayer.fromFunction(TodoEventSourcedServiceLive.apply),
+    )
+
+object TodoNativeLocalEventSourcingApp extends ZIOAppDefault:
+  private val snapshotPath = Paths.get("todo-native-local-event-sourcing.snapshot.json")
+
+  override def run: URIO[ZIOAppArgs & Scope, Any] =
+    val program =
+      for
+        addedOne <- TodoEventSourcedService.add("write event journal guide", "high")
+        _        <- TodoEventSourcedService.add("document replay semantics", "normal")
+        _        <- TodoEventSourcedService.complete(addedOne.id)
+        root     <- TodoEventSourcedService.checkpointAndReload
+        replayed <- TodoEventSourcedService.replayedState
+        _        <- ZIO.logInfo(
+                      s"Reloaded ${root.journal.size} journal entries and ${root.snapshot.items.size} projected todos"
+                    )
+        _        <- ZIO.logDebug(s"Projection matches replay: ${root.snapshot == replayed}")
+        _        <- ZIO.logInfo(s"Snapshot file: $snapshotPath")
+      yield ()
+
+    program
+      .provide(TodoEventSourcedService.layer(snapshotPath))
+      .catchAll(error => ZIO.logError(error.toString))

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningApp.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningApp.scala
@@ -1,0 +1,218 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal
+
+import java.nio.file.{ Path, Paths }
+import java.util.UUID
+
+import zio.*
+import zio.json.ast.Json
+import zio.schema.{ DeriveSchema, Schema }
+
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, NativeLocalSerde }
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.schema.{ Migration, MigrationPlan }
+import io.github.riccardomerolla.zio.eclipsestore.service.{ ObjectStore, SnapshotCodec, StorageBackend, StorageOps }
+
+enum TodoSchemaVersion:
+  case V1
+  case V2
+
+object TodoSchemaVersion:
+  given Schema[TodoSchemaVersion] = DeriveSchema.gen[TodoSchemaVersion]
+
+final case class TodoItemV1(
+  id: TodoId,
+  title: String,
+  completed: Boolean,
+  legacyCategory: String,
+)
+
+object TodoItemV1:
+  given Schema[TodoItemV1] = DeriveSchema.gen[TodoItemV1]
+
+final case class TodoRootV1(items: Chunk[TodoItemV1])
+
+object TodoRootV1:
+  given Schema[TodoRootV1] = DeriveSchema.gen[TodoRootV1]
+
+  val descriptor: RootDescriptor[TodoRootV1] =
+    RootDescriptor.fromSchema(
+      id = "todo-native-local-versioned-root",
+      initializer = () => TodoRootV1(Chunk.empty),
+    )
+
+final case class TodoItemV2(
+  id: TodoId,
+  title: String,
+  completed: Boolean,
+  priority: String,
+)
+
+object TodoItemV2:
+  given Schema[TodoItemV2] = DeriveSchema.gen[TodoItemV2]
+
+final case class TodoRootV2(items: Chunk[TodoItemV2])
+
+object TodoRootV2:
+  given Schema[TodoRootV2] = DeriveSchema.gen[TodoRootV2]
+
+  val descriptor: RootDescriptor[TodoRootV2] =
+    RootDescriptor.fromSchema(
+      id = "todo-native-local-versioned-root",
+      initializer = () => TodoRootV2(Chunk.empty),
+    )
+
+final case class TodoMigrationReport(
+  from: TodoSchemaVersion,
+  to: TodoSchemaVersion,
+  migratedTodos: Int,
+)
+
+object TodoMigrationReport:
+  given Schema[TodoMigrationReport] = DeriveSchema.gen[TodoMigrationReport]
+
+trait TodoV1Service:
+  def add(title: String, legacyCategory: String): IO[EclipseStoreError, TodoItemV1]
+  def complete(id: TodoId): IO[EclipseStoreError, TodoItemV1]
+  def checkpoint: IO[EclipseStoreError, Unit]
+
+final case class TodoV1ServiceLive(
+  store: ObjectStore[TodoRootV1],
+  ops: StorageOps[TodoRootV1],
+) extends TodoV1Service:
+  override def add(title: String, legacyCategory: String): IO[EclipseStoreError, TodoItemV1] =
+    store.modify { root =>
+      val item = TodoItemV1(TodoId(UUID.randomUUID()), title, completed = false, legacyCategory)
+      ZIO.succeed((item, root.copy(items = root.items :+ item)))
+    }
+
+  override def complete(id: TodoId): IO[EclipseStoreError, TodoItemV1] =
+    store.modify { root =>
+      root.items.indexWhere(_.id == id) match
+        case -1    =>
+          ZIO.fail(EclipseStoreError.QueryError(s"Legacy todo ${id.value} not found", None))
+        case index =>
+          val updated = root.items(index).copy(completed = true)
+          ZIO.succeed((updated, root.copy(items = root.items.updated(index, updated))))
+    }
+
+  override def checkpoint: IO[EclipseStoreError, Unit] =
+    ops.checkpoint.unit
+
+object TodoV1Service:
+  def add(title: String, legacyCategory: String): ZIO[TodoV1Service, EclipseStoreError, TodoItemV1] =
+    ZIO.serviceWithZIO[TodoV1Service](_.add(title, legacyCategory))
+
+  def complete(id: TodoId): ZIO[TodoV1Service, EclipseStoreError, TodoItemV1] =
+    ZIO.serviceWithZIO[TodoV1Service](_.complete(id))
+
+  val checkpoint: ZIO[TodoV1Service, EclipseStoreError, Unit] =
+    ZIO.serviceWithZIO[TodoV1Service](_.checkpoint)
+
+  def layer(
+    snapshotPath: Path,
+    serde: NativeLocalSerde = NativeLocalSerde.Json,
+  ): ZLayer[Any, EclipseStoreError, TodoV1Service] =
+    ZLayer.make[TodoV1Service](
+      ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath, serde)),
+      StorageBackend.rootServices(TodoRootV1.descriptor),
+      ZLayer.fromFunction(TodoV1ServiceLive.apply),
+    )
+
+trait TodoV2Service:
+  def add(title: String, priority: String): IO[EclipseStoreError, TodoItemV2]
+  def list: IO[EclipseStoreError, Chunk[TodoItemV2]]
+  def checkpointAndReload: IO[EclipseStoreError, Chunk[TodoItemV2]]
+
+final case class TodoV2ServiceLive(
+  store: ObjectStore[TodoRootV2],
+  ops: StorageOps[TodoRootV2],
+) extends TodoV2Service:
+  override def add(title: String, priority: String): IO[EclipseStoreError, TodoItemV2] =
+    store.modify { root =>
+      val item = TodoItemV2(TodoId(UUID.randomUUID()), title, completed = false, priority)
+      ZIO.succeed((item, root.copy(items = root.items :+ item)))
+    }
+
+  override def list: IO[EclipseStoreError, Chunk[TodoItemV2]] =
+    store.load.map(_.items)
+
+  override def checkpointAndReload: IO[EclipseStoreError, Chunk[TodoItemV2]] =
+    ops.checkpoint *> ops.restart *> list
+
+object TodoV2Service:
+  def add(title: String, priority: String): ZIO[TodoV2Service, EclipseStoreError, TodoItemV2] =
+    ZIO.serviceWithZIO[TodoV2Service](_.add(title, priority))
+
+  val list: ZIO[TodoV2Service, EclipseStoreError, Chunk[TodoItemV2]] =
+    ZIO.serviceWithZIO[TodoV2Service](_.list)
+
+  val checkpointAndReload: ZIO[TodoV2Service, EclipseStoreError, Chunk[TodoItemV2]] =
+    ZIO.serviceWithZIO[TodoV2Service](_.checkpointAndReload)
+
+  def layer(
+    snapshotPath: Path,
+    serde: NativeLocalSerde = NativeLocalSerde.Json,
+  ): ZLayer[Any, EclipseStoreError, TodoV2Service] =
+    ZLayer.make[TodoV2Service](
+      ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath, serde)),
+      StorageBackend.rootServices(TodoRootV2.descriptor),
+      ZLayer.fromFunction(TodoV2ServiceLive.apply),
+    )
+
+object TodoVersioning:
+  val itemV1ToV2: MigrationPlan[TodoItemV1, TodoItemV2] =
+    Migration
+      .define[TodoItemV1, TodoItemV2](
+        Migration.removeField("legacyCategory"),
+        Migration.addField("priority", Json.Str("normal")),
+      )
+      .plan
+
+  def migrateSnapshot(
+    snapshotPath: Path,
+    serde: NativeLocalSerde = NativeLocalSerde.Json,
+  ): IO[EclipseStoreError, TodoMigrationReport] =
+    val v1Codec = SnapshotCodec.forSerde[TodoRootV1](serde)
+    val v2Codec = SnapshotCodec.forSerde[TodoRootV2](serde)
+
+    for
+      _        <- itemV1ToV2.validate
+      existing <- SnapshotCodec.loadOrElse(snapshotPath, TodoRootV1(Chunk.empty))(using v1Codec)
+      migrated <- ZIO.foreach(existing.items)(itemV1ToV2.migrate).map(TodoRootV2.apply)
+      _        <- SnapshotCodec.save(snapshotPath, migrated)(using v2Codec)
+    yield TodoMigrationReport(
+      from = TodoSchemaVersion.V1,
+      to = TodoSchemaVersion.V2,
+      migratedTodos = existing.items.size,
+    )
+
+object TodoNativeLocalVersioningApp extends ZIOAppDefault:
+  private val snapshotPath = Paths.get("todo-native-local-versioned.snapshot.json")
+
+  override def run: URIO[ZIOAppArgs & Scope, Any] =
+    val seedV1 =
+      (for
+        first  <- TodoV1Service.add("write migration guide", "docs")
+        second <- TodoV1Service.add("retire v1 category field", "ops")
+        _      <- TodoV1Service.complete(first.id)
+        _      <- TodoV1Service.checkpoint
+      yield second.id).provide(TodoV1Service.layer(snapshotPath))
+
+    val continueWithV2 =
+      (for
+        before   <- TodoV2Service.list
+        added    <- TodoV2Service.add("create v2-only todo", "high")
+        reloaded <- TodoV2Service.checkpointAndReload
+        _        <- ZIO.logInfo(
+                      s"Loaded ${before.size} migrated todos and ${reloaded.size} total todos after adding ${added.title}"
+                    )
+        _        <- ZIO.logInfo(s"Snapshot file: $snapshotPath")
+      yield ()).provide(TodoV2Service.layer(snapshotPath))
+
+    (for
+      _      <- seedV1
+      report <- TodoVersioning.migrateSnapshot(snapshotPath)
+      _      <- ZIO.logInfo(s"Migrated ${report.migratedTodos} todos from ${report.from} to ${report.to}")
+      _      <- continueWithV2
+    yield ()).catchAll(error => ZIO.logError(error.toString))

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningApp.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningApp.scala
@@ -10,8 +10,8 @@ import zio.schema.{ DeriveSchema, Schema }
 import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, NativeLocalSerde }
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
-import io.github.riccardomerolla.zio.eclipsestore.schema.{ Migration, MigrationPlan }
-import io.github.riccardomerolla.zio.eclipsestore.service.{ ObjectStore, SnapshotCodec, StorageBackend, StorageOps }
+import io.github.riccardomerolla.zio.eclipsestore.schema.DerivedMigrationPlan
+import io.github.riccardomerolla.zio.eclipsestore.service.*
 
 enum TodoSchemaVersion:
   case V1
@@ -153,38 +153,53 @@ object TodoV2Service:
   def layer(
     snapshotPath: Path,
     serde: NativeLocalSerde = NativeLocalSerde.Json,
+    migrationRegistry: NativeLocalSnapshotMigrationRegistry[TodoRootV2] = NativeLocalSnapshotMigrationRegistry
+      .none[TodoRootV2],
   ): ZLayer[Any, EclipseStoreError, TodoV2Service] =
     ZLayer.make[TodoV2Service](
       ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath, serde)),
-      StorageBackend.rootServices(TodoRootV2.descriptor),
+      StorageBackend.rootServices(TodoRootV2.descriptor, migrationRegistry = migrationRegistry),
       ZLayer.fromFunction(TodoV2ServiceLive.apply),
     )
 
+  def autoLayer(
+    snapshotPath: Path,
+    serde: NativeLocalSerde = NativeLocalSerde.Json,
+  ): ZLayer[Any, EclipseStoreError, TodoV2Service] =
+    layer(snapshotPath, serde, TodoVersioning.migrationRegistry)
+
 object TodoVersioning:
-  val itemV1ToV2: MigrationPlan[TodoItemV1, TodoItemV2] =
-    Migration
-      .define[TodoItemV1, TodoItemV2](
-        Migration.removeField("legacyCategory"),
-        Migration.addField("priority", Json.Str("normal")),
-      )
-      .plan
+  val itemV1ToV2: DerivedMigrationPlan[TodoItemV1, TodoItemV2] =
+    DerivedMigrationPlan.derive[TodoItemV1, TodoItemV2](
+      newFieldDefaults = Map("priority" -> Json.Str("normal"))
+    )
+
+  val migrationRegistry: NativeLocalSnapshotMigrationRegistry[TodoRootV2] =
+    NativeLocalSnapshotMigrationRegistry.single(
+      NativeLocalSnapshotMigration.fromFunction[TodoRootV1, TodoRootV2](TodoRootV1.descriptor.id) { legacy =>
+        itemV1ToV2.validate *>
+          ZIO.foreach(legacy.items)(itemV1ToV2.migrate).map(TodoRootV2.apply)
+      }
+    )
 
   def migrateSnapshot(
     snapshotPath: Path,
     serde: NativeLocalSerde = NativeLocalSerde.Json,
   ): IO[EclipseStoreError, TodoMigrationReport] =
-    val v1Codec = SnapshotCodec.forSerde[TodoRootV1](serde)
-    val v2Codec = SnapshotCodec.forSerde[TodoRootV2](serde)
-
     for
       _        <- itemV1ToV2.validate
-      existing <- SnapshotCodec.loadOrElse(snapshotPath, TodoRootV1(Chunk.empty))(using v1Codec)
-      migrated <- ZIO.foreach(existing.items)(itemV1ToV2.migrate).map(TodoRootV2.apply)
-      _        <- SnapshotCodec.save(snapshotPath, migrated)(using v2Codec)
+      existing <- SnapshotCodec.loadEnvelopedOrElse(
+                    snapshotPath,
+                    TodoRootV1.descriptor.id,
+                    serde,
+                    TodoRootV1(Chunk.empty),
+                  )
+      migrated <- ZIO.foreach(existing.value.items)(itemV1ToV2.migrate).map(TodoRootV2.apply)
+      _        <- SnapshotCodec.saveEnveloped(snapshotPath, migrated, TodoRootV2.descriptor.id, serde)
     yield TodoMigrationReport(
       from = TodoSchemaVersion.V1,
       to = TodoSchemaVersion.V2,
-      migratedTodos = existing.items.size,
+      migratedTodos = existing.value.items.size,
     )
 
 object TodoNativeLocalVersioningApp extends ZIOAppDefault:
@@ -208,11 +223,9 @@ object TodoNativeLocalVersioningApp extends ZIOAppDefault:
                       s"Loaded ${before.size} migrated todos and ${reloaded.size} total todos after adding ${added.title}"
                     )
         _        <- ZIO.logInfo(s"Snapshot file: $snapshotPath")
-      yield ()).provide(TodoV2Service.layer(snapshotPath))
+      yield ()).provide(TodoV2Service.autoLayer(snapshotPath))
 
     (for
-      _      <- seedV1
-      report <- TodoVersioning.migrateSnapshot(snapshotPath)
-      _      <- ZIO.logInfo(s"Migrated ${report.migratedTodos} todos from ${report.from} to ${report.to}")
-      _      <- continueWithV2
+      _ <- seedV1
+      _ <- continueWithV2
     yield ()).catchAll(error => ZIO.logError(error.toString))

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/observability/StorageEvent.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/observability/StorageEvent.scala
@@ -1,0 +1,49 @@
+package io.github.riccardomerolla.zio.eclipsestore.observability
+
+import zio.Duration
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** Typed observability vocabulary for persistence, operations, and contention signals. */
+enum StorageEvent:
+  case OperationSucceeded(
+    operation: String,
+    duration: Duration,
+    persistedObjects: Int = 0,
+    detail: Option[String] = None,
+  )
+  case OperationFailed(
+    operation: String,
+    duration: Duration,
+    error: EclipseStoreError,
+  )
+  case SlowOperationDetected(
+    operation: String,
+    duration: Duration,
+    threshold: Duration,
+  )
+  case LockContentionDetected(
+    operation: String,
+    duration: Duration,
+    threshold: Duration,
+  )
+
+  def operationName: String =
+    this match
+      case StorageEvent.OperationSucceeded(operation, _, _, _)  => operation
+      case StorageEvent.OperationFailed(operation, _, _)        => operation
+      case StorageEvent.SlowOperationDetected(operation, _, _)  => operation
+      case StorageEvent.LockContentionDetected(operation, _, _) => operation
+
+  def message: String =
+    this match
+      case StorageEvent.OperationSucceeded(operation, duration, persistedObjects, detail) =>
+        val persistedPart = if persistedObjects > 0 then s", persistedObjects=$persistedObjects" else ""
+        val detailPart    = detail.fold("")(value => s", detail=$value")
+        s"storage operation succeeded: operation=$operation, duration=$duration$persistedPart$detailPart"
+      case StorageEvent.OperationFailed(operation, duration, error)                       =>
+        s"storage operation failed: operation=$operation, duration=$duration, error=$error"
+      case StorageEvent.SlowOperationDetected(operation, duration, threshold)             =>
+        s"slow storage operation detected: operation=$operation, duration=$duration, threshold=$threshold"
+      case StorageEvent.LockContentionDetected(operation, duration, threshold)            =>
+        s"lock contention detected: operation=$operation, duration=$duration, threshold=$threshold"

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/observability/StorageMetrics.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/observability/StorageMetrics.scala
@@ -1,0 +1,117 @@
+package io.github.riccardomerolla.zio.eclipsestore.observability
+
+import zio.*
+
+trait StorageMetrics:
+  def record(event: StorageEvent): UIO[Unit]
+  def snapshot: UIO[StorageMetrics.Snapshot]
+
+object StorageMetrics:
+  final case class Snapshot(
+    persistedObjects: Long = 0L,
+    successfulOperations: Long = 0L,
+    failedOperations: Long = 0L,
+    slowOperations: Long = 0L,
+    lockContentionEvents: Long = 0L,
+    operationCounts: Map[String, Long] = Map.empty,
+    durationSamplesMillis: Map[String, Chunk[Long]] = Map.empty,
+    latestDurationGaugeMillis: Map[String, Long] = Map.empty,
+    events: Chunk[StorageEvent] = Chunk.empty,
+  )
+
+  val inMemory: ULayer[StorageMetrics] =
+    ZLayer.fromZIO {
+      Ref.make(Snapshot()).map(InMemoryStorageMetrics(_))
+    }
+
+  val noop: ULayer[StorageMetrics] =
+    ZLayer.succeed(
+      new StorageMetrics:
+        override def record(event: StorageEvent): UIO[Unit] = ZIO.unit
+        override def snapshot: UIO[Snapshot]                = ZIO.succeed(Snapshot())
+    )
+
+  val snapshot: ZIO[StorageMetrics, Nothing, Snapshot] =
+    ZIO.serviceWithZIO[StorageMetrics](_.snapshot)
+
+  def record(event: StorageEvent): ZIO[StorageMetrics, Nothing, Unit] =
+    ZIO.serviceWithZIO[StorageMetrics](_.record(event))
+
+final private case class InMemoryStorageMetrics(ref: Ref[StorageMetrics.Snapshot]) extends StorageMetrics:
+  override def record(event: StorageEvent): UIO[Unit] =
+    ref.update(snapshot => updateSnapshot(snapshot, event))
+
+  override def snapshot: UIO[StorageMetrics.Snapshot] =
+    ref.get
+
+  private def updateSnapshot(snapshot: StorageMetrics.Snapshot, event: StorageEvent): StorageMetrics.Snapshot =
+    val withEvent = snapshot.copy(events = snapshot.events :+ event)
+
+    event match
+      case StorageEvent.OperationSucceeded(operation, duration, persistedObjects, _) =>
+        registerDuration(
+          increment(
+            withEvent.copy(
+              persistedObjects = withEvent.persistedObjects + persistedObjects.toLong,
+              successfulOperations = withEvent.successfulOperations + 1L,
+            ),
+            s"$operation.success",
+          ),
+          operation,
+          duration,
+        )
+
+      case StorageEvent.OperationFailed(operation, duration, _) =>
+        registerDuration(
+          increment(
+            withEvent.copy(
+              failedOperations = withEvent.failedOperations + 1L
+            ),
+            s"$operation.failure",
+          ),
+          operation,
+          duration,
+        )
+
+      case StorageEvent.SlowOperationDetected(operation, duration, _) =>
+        registerDuration(
+          increment(
+            withEvent.copy(
+              slowOperations = withEvent.slowOperations + 1L
+            ),
+            s"$operation.slow",
+          ),
+          operation,
+          duration,
+        )
+
+      case StorageEvent.LockContentionDetected(operation, duration, _) =>
+        registerDuration(
+          increment(
+            withEvent.copy(
+              lockContentionEvents = withEvent.lockContentionEvents + 1L
+            ),
+            s"$operation.contention",
+          ),
+          operation,
+          duration,
+        )
+
+  private def increment(snapshot: StorageMetrics.Snapshot, key: String): StorageMetrics.Snapshot =
+    snapshot.copy(operationCounts =
+      snapshot.operationCounts.updated(key, snapshot.operationCounts.getOrElse(key, 0L) + 1L)
+    )
+
+  private def registerDuration(
+    snapshot: StorageMetrics.Snapshot,
+    operation: String,
+    duration: Duration,
+  ): StorageMetrics.Snapshot =
+    val millis = duration.toMillis
+    snapshot.copy(
+      durationSamplesMillis = snapshot.durationSamplesMillis.updated(
+        operation,
+        snapshot.durationSamplesMillis.getOrElse(operation, Chunk.empty) :+ millis,
+      ),
+      latestDurationGaugeMillis = snapshot.latestDurationGaugeMillis.updated(operation, millis),
+    )

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/observability/StorageObservability.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/observability/StorageObservability.scala
@@ -1,0 +1,246 @@
+package io.github.riccardomerolla.zio.eclipsestore.observability
+
+import zio.*
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.{
+  LifecycleStatus,
+  ObjectStore,
+  StorageLock,
+  StorageOps,
+  Transaction,
+}
+
+object StorageObservability:
+  final case class Settings(
+    slowOperationThreshold: Duration = 100.millis,
+    lockContentionThreshold: Duration = 50.millis,
+  )
+
+  def objectStore[Root: Tag](settings: Settings = Settings())
+    : ZLayer[ObjectStore[Root] & StorageMetrics, Nothing, ObjectStore[Root]] =
+    ZLayer.fromZIO {
+      for
+        store   <- ZIO.service[ObjectStore[Root]]
+        metrics <- ZIO.service[StorageMetrics]
+      yield instrumentObjectStore(store, metrics, settings)
+    }
+
+  def storageOps[Root: Tag](settings: Settings = Settings())
+    : ZLayer[StorageOps[Root] & StorageMetrics, Nothing, StorageOps[Root]] =
+    ZLayer.fromZIO {
+      for
+        ops     <- ZIO.service[StorageOps[Root]]
+        metrics <- ZIO.service[StorageMetrics]
+      yield instrumentStorageOps(ops, metrics, settings)
+    }
+
+  def storageLock[Root: Tag](settings: Settings = Settings())
+    : ZLayer[StorageLock[Root] & StorageMetrics, Nothing, StorageLock[Root]] =
+    ZLayer.fromZIO {
+      for
+        lock    <- ZIO.service[StorageLock[Root]]
+        metrics <- ZIO.service[StorageMetrics]
+      yield instrumentStorageLock(lock, metrics, settings)
+    }
+
+  def instrumentObjectStore[Root](
+    underlying: ObjectStore[Root],
+    metrics: StorageMetrics,
+    settings: Settings = Settings(),
+  ): ObjectStore[Root] =
+    InstrumentedObjectStore(underlying, metrics, settings)
+
+  def instrumentStorageOps[Root](
+    underlying: StorageOps[Root],
+    metrics: StorageMetrics,
+    settings: Settings = Settings(),
+  ): StorageOps[Root] =
+    InstrumentedStorageOps(underlying, metrics, settings)
+
+  def instrumentStorageLock[Root](
+    underlying: StorageLock[Root],
+    metrics: StorageMetrics,
+    settings: Settings = Settings(),
+  ): StorageLock[Root] =
+    InstrumentedStorageLock(underlying, metrics, settings)
+
+  private[observability] def logAndRecord(metrics: StorageMetrics, event: StorageEvent): UIO[Unit] =
+    metrics.record(event) *>
+      ZIO.logAnnotate("storage.operation", event.operationName) {
+        event match
+          case _: StorageEvent.OperationSucceeded => ZIO.logInfo(event.message)
+          case _: StorageEvent.OperationFailed    => ZIO.logError(event.message)
+          case _: StorageEvent.SlowOperationDetected |
+               _: StorageEvent.LockContentionDetected =>
+            ZIO.logWarning(event.message)
+      }
+
+  private[observability] def observe[A](
+    metrics: StorageMetrics,
+    settings: Settings,
+    operation: String,
+    persistedObjects: Int = 0,
+    contentionThreshold: Option[Duration] = None,
+    detail: Option[String] = None,
+  )(
+    effect: IO[EclipseStoreError, A]
+  ): IO[EclipseStoreError, A] =
+    for
+      started <- Clock.nanoTime
+      exit    <- effect.exit
+      ended   <- Clock.nanoTime
+      duration = (ended - started).nanos
+      _       <- exit match
+                   case Exit.Success(_)     =>
+                     logAndRecord(metrics, StorageEvent.OperationSucceeded(operation, duration, persistedObjects, detail))
+                   case Exit.Failure(cause) =>
+                     cause.failureOption match
+                       case Some(error: EclipseStoreError) =>
+                         logAndRecord(metrics, StorageEvent.OperationFailed(operation, duration, error))
+                       case _                              =>
+                         ZIO.unit
+      _       <- ZIO.when(duration >= settings.slowOperationThreshold) {
+                   logAndRecord(
+                     metrics,
+                     StorageEvent.SlowOperationDetected(operation, duration, settings.slowOperationThreshold),
+                   )
+                 }
+      _       <- ZIO.foreachDiscard(contentionThreshold)(threshold =>
+                   ZIO.when(duration >= threshold) {
+                     logAndRecord(metrics, StorageEvent.LockContentionDetected(operation, duration, threshold))
+                   }
+                 )
+      result  <- ZIO.done(exit)
+    yield result
+
+final private case class InstrumentedObjectStore[Root](
+  underlying: ObjectStore[Root],
+  metrics: StorageMetrics,
+  settings: StorageObservability.Settings,
+) extends ObjectStore[Root]:
+  override def descriptor: RootDescriptor[Root] = underlying.descriptor
+
+  override def load: IO[EclipseStoreError, Root] =
+    StorageObservability.observe(metrics, settings, "object-store.load")(underlying.load)
+
+  override def storeSubgraph(subgraph: AnyRef): IO[EclipseStoreError, Unit] =
+    StorageObservability.observe(metrics, settings, "object-store.store-subgraph", persistedObjects = 1)(
+      underlying.storeSubgraph(subgraph)
+    )
+
+  override def storeRoot: IO[EclipseStoreError, Unit] =
+    StorageObservability.observe(metrics, settings, "object-store.store-root", persistedObjects = 1)(
+      underlying.storeRoot
+    )
+
+  override def checkpoint: IO[EclipseStoreError, Unit] =
+    StorageObservability.observe(metrics, settings, "object-store.checkpoint", persistedObjects = 1)(
+      underlying.checkpoint
+    )
+
+  override def transact[A](transaction: Transaction[Root, A]): ZIO[Any, EclipseStoreError, A] =
+    StorageObservability.observe(metrics, settings, "object-store.transact", persistedObjects = 1)(
+      underlying.transact(transaction)
+    )
+
+final private case class InstrumentedStorageOps[Root](
+  underlying: StorageOps[Root],
+  metrics: StorageMetrics,
+  settings: StorageObservability.Settings,
+) extends StorageOps[Root]:
+  override def descriptor: RootDescriptor[Root] = underlying.descriptor
+
+  override def load: IO[EclipseStoreError, Root] =
+    StorageObservability.observe(metrics, settings, "storage-ops.load")(underlying.load)
+
+  override def status: ZIO[Any, Nothing, LifecycleStatus] =
+    underlying.status
+
+  override def checkpoint: ZIO[Any, EclipseStoreError, LifecycleStatus] =
+    StorageObservability.observe(metrics, settings, "storage-ops.checkpoint", persistedObjects = 1)(
+      underlying.checkpoint
+    )
+
+  override def backup(target: java.nio.file.Path, includeConfig: Boolean = true)
+    : ZIO[Any, EclipseStoreError, LifecycleStatus] =
+    StorageObservability.observe(metrics, settings, "storage-ops.backup", detail = Some(target.toString))(
+      underlying.backup(target, includeConfig)
+    )
+
+  override def exportTo(target: java.nio.file.Path): ZIO[Any, EclipseStoreError, LifecycleStatus] =
+    StorageObservability.observe(metrics, settings, "storage-ops.export", detail = Some(target.toString))(
+      underlying.exportTo(target)
+    )
+
+  override def importFrom(source: java.nio.file.Path): ZIO[Any, EclipseStoreError, LifecycleStatus] =
+    StorageObservability.observe(
+      metrics,
+      settings,
+      "storage-ops.import",
+      persistedObjects = 1,
+      detail = Some(source.toString),
+    )(
+      underlying.importFrom(source)
+    )
+
+  override def restoreFrom(source: java.nio.file.Path): ZIO[Any, EclipseStoreError, LifecycleStatus] =
+    StorageObservability.observe(
+      metrics,
+      settings,
+      "storage-ops.restore",
+      persistedObjects = 1,
+      detail = Some(source.toString),
+    )(
+      underlying.restoreFrom(source)
+    )
+
+  override def restart: ZIO[Any, EclipseStoreError, LifecycleStatus] =
+    StorageObservability.observe(metrics, settings, "storage-ops.restart")(underlying.restart)
+
+  override def shutdown: ZIO[Any, EclipseStoreError, LifecycleStatus] =
+    StorageObservability.observe(metrics, settings, "storage-ops.shutdown")(underlying.shutdown)
+
+  override def housekeep: ZIO[Any, EclipseStoreError, LifecycleStatus] =
+    StorageObservability.observe(metrics, settings, "storage-ops.housekeep")(underlying.housekeep)
+
+  override def scheduleCheckpoints(schedule: Schedule[Any, Any, Any])
+    : ZIO[Scope, Nothing, Fiber.Runtime[Nothing, Unit]] =
+    underlying.scheduleCheckpoints(schedule)
+
+final private case class InstrumentedStorageLock[Root](
+  underlying: StorageLock[Root],
+  metrics: StorageMetrics,
+  settings: StorageObservability.Settings,
+) extends StorageLock[Root]:
+  override def readLock[A](effect: Root => IO[EclipseStoreError, A]): ZIO[Any, EclipseStoreError, A] =
+    StorageObservability.observe(
+      metrics,
+      settings,
+      "storage-lock.read",
+      contentionThreshold = Some(settings.lockContentionThreshold),
+    )(underlying.readLock(effect))
+
+  override def writeLock[A](effect: Root => IO[EclipseStoreError, A]): ZIO[Any, EclipseStoreError, A] =
+    StorageObservability.observe(
+      metrics,
+      settings,
+      "storage-lock.write",
+      persistedObjects = 1,
+      contentionThreshold = Some(settings.lockContentionThreshold),
+    )(underlying.writeLock(effect))
+
+  override def optimisticUpdate[A](
+    prepare: Root => IO[EclipseStoreError, A]
+  )(
+    commit: (Root, A) => IO[EclipseStoreError, A],
+    maxRetries: Int = 8,
+  ): ZIO[Any, EclipseStoreError, A] =
+    StorageObservability.observe(
+      metrics,
+      settings,
+      "storage-lock.optimistic-update",
+      persistedObjects = 1,
+      contentionThreshold = Some(settings.lockContentionThreshold),
+    )(underlying.optimisticUpdate(prepare)(commit, maxRetries))

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/observability/StorageObservability.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/observability/StorageObservability.scala
@@ -125,6 +125,16 @@ final private case class InstrumentedObjectStore[Root](
   override def load: IO[EclipseStoreError, Root] =
     StorageObservability.observe(metrics, settings, "object-store.load")(underlying.load)
 
+  override def replace(root: Root): IO[EclipseStoreError, Unit] =
+    StorageObservability.observe(metrics, settings, "object-store.replace", persistedObjects = 1)(
+      underlying.replace(root)
+    )
+
+  override def modify[A](f: Root => IO[EclipseStoreError, (A, Root)]): IO[EclipseStoreError, A] =
+    StorageObservability.observe(metrics, settings, "object-store.modify", persistedObjects = 1)(
+      underlying.modify(f)
+    )
+
   override def storeSubgraph(subgraph: AnyRef): IO[EclipseStoreError, Unit] =
     StorageObservability.observe(metrics, settings, "object-store.store-subgraph", persistedObjects = 1)(
       underlying.storeSubgraph(subgraph)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/DerivedMigrationPlan.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/DerivedMigrationPlan.scala
@@ -1,0 +1,55 @@
+package io.github.riccardomerolla.zio.eclipsestore.schema
+
+import zio.*
+import zio.json.ast.Json
+import zio.schema.Schema
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+final case class DerivedMigrationPlan[Old, New](
+  autoDerived: Chunk[MigrationStep],
+  overrides: Chunk[MigrationStep],
+  delegate: MigrationPlan[Old, New],
+):
+  def steps: Chunk[MigrationStep] =
+    autoDerived ++ overrides
+
+  def validate: IO[EclipseStoreError, Unit] =
+    delegate.validate
+
+  def migrate(value: Old): IO[EclipseStoreError, New] =
+    delegate.migrate(value)
+
+  def migratePayload(payload: String): IO[EclipseStoreError, New] =
+    delegate.migratePayload(payload)
+
+object DerivedMigrationPlan:
+  def derive[Old: Schema, New: Schema](
+    newFieldDefaults: Map[String, Json] = Map.empty,
+    overrides: MigrationStep*
+  ): DerivedMigrationPlan[Old, New] =
+    val overrideChunk   = Chunk.fromIterable(overrides)
+    val coveredFields   = overrideChunk.flatMap(coveredFieldNames).toSet
+    val oldFields       = SchemaIntrospection.topLevelFields(summon[Schema[Old]])
+    val newFields       = SchemaIntrospection.topLevelFields(summon[Schema[New]])
+    val removedFields   =
+      Chunk.fromIterable(oldFields.keySet.diff(newFields.keySet).diff(coveredFields)).map(Migration.removeField)
+    val autoAddedFields =
+      Chunk.fromIterable(newFields.keySet.diff(oldFields.keySet).diff(coveredFields))
+        .flatMap(name => newFieldDefaults.get(name).map(Migration.addField(name, _)))
+    val delegate        = Migration[Old, New](removedFields ++ autoAddedFields ++ overrideChunk).plan
+
+    DerivedMigrationPlan(
+      autoDerived = removedFields ++ autoAddedFields,
+      overrides = overrideChunk,
+      delegate = delegate,
+    )
+
+  private def coveredFieldNames(step: MigrationStep): Chunk[String] =
+    step match
+      case MigrationStep.AddField(name, _)         => Chunk(name)
+      case MigrationStep.RemoveField(name)         => Chunk(name)
+      case MigrationStep.RenameField(from, to)     => Chunk(from, to)
+      case MigrationStep.ChangeField(name, _)      => Chunk(name)
+      case MigrationStep.SplitField(name, targets) => Chunk(name) ++ targets.map(_._1)
+      case MigrationStep.MergeFields(names, to, _) => names ++ Chunk(to)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/Migration.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/Migration.scala
@@ -272,18 +272,6 @@ final case class MigrationPlan[Old, New](
         case Left(error)  =>
           ZIO.fail(EclipseStoreError.MigrationError(s"Failed to decode migrated payload: $error", None))
       }
-
-private object SchemaIntrospection:
-  def topLevelFields[A](schema: Schema[A]): Map[String, String] =
-    schema match
-      case record: Schema.Record[A] =>
-        record.fields.map(field => field.name -> stableShape(field.schema.asInstanceOf[Schema[?]])).toMap
-      case _                        =>
-        Map.empty
-
-  private def stableShape(schema: Schema[?]): String =
-    schema.ast.toString
-
 final private case class ValidationCoverage(
   createdFields: Set[String],
   consumedFields: Set[String],

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/Migration.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/Migration.scala
@@ -1,0 +1,320 @@
+package io.github.riccardomerolla.zio.eclipsestore.schema
+
+import scala.collection.immutable.ListMap
+
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.schema.Schema
+import zio.schema.codec.JsonCodec
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+type JsonFieldMap = ListMap[String, Json]
+
+final case class Migration[Old, New](steps: Chunk[MigrationStep]):
+  def andThen[Next](next: Migration[New, Next]): Migration[Old, Next] =
+    Migration(steps ++ next.steps)
+
+  def plan(using oldSchema: Schema[Old], newSchema: Schema[New]): MigrationPlan[Old, New] =
+    MigrationPlan(this, oldSchema, newSchema)
+
+object Migration:
+  def empty[A]: Migration[A, A] =
+    Migration(Chunk.empty)
+
+  def define[Old, New](steps: MigrationStep*): Migration[Old, New] =
+    Migration(Chunk.fromIterable(steps))
+
+  def addField(name: String, defaultValue: Json): MigrationStep =
+    MigrationStep.AddField(name, defaultValue)
+
+  def removeField(name: String): MigrationStep =
+    MigrationStep.RemoveField(name)
+
+  def renameField(from: String, to: String): MigrationStep =
+    MigrationStep.RenameField(from, to)
+
+  def changeField(name: String)(convert: Json => IO[EclipseStoreError, Json]): MigrationStep =
+    MigrationStep.ChangeField(name, convert)
+
+  def splitField(name: String)(targets: (String, Json => IO[EclipseStoreError, Json])*): MigrationStep =
+    MigrationStep.SplitField(name, Chunk.fromIterable(targets))
+
+  def mergeFields(names: String*)(to: String)(combine: Chunk[Json] => IO[EclipseStoreError, Json]): MigrationStep =
+    MigrationStep.MergeFields(Chunk.fromIterable(names), to, combine)
+
+sealed trait MigrationStep:
+  def summary: String
+
+  private[schema] def apply(fields: JsonFieldMap): IO[EclipseStoreError, JsonFieldMap]
+
+object MigrationStep:
+  final case class AddField(name: String, defaultValue: Json) extends MigrationStep:
+    override val summary: String = s"add-field($name)"
+
+    override private[schema] def apply(fields: JsonFieldMap): IO[EclipseStoreError, JsonFieldMap] =
+      if fields.contains(name) then ZIO.succeed(fields)
+      else ZIO.succeed(fields.updated(name, defaultValue))
+
+  final case class RemoveField(name: String) extends MigrationStep:
+    override val summary: String = s"remove-field($name)"
+
+    override private[schema] def apply(fields: JsonFieldMap): IO[EclipseStoreError, JsonFieldMap] =
+      if fields.contains(name) then ZIO.succeed(fields.removed(name))
+      else missingField(name, summary)
+
+  final case class RenameField(from: String, to: String) extends MigrationStep:
+    override val summary: String = s"rename-field($from->$to)"
+
+    override private[schema] def apply(fields: JsonFieldMap): IO[EclipseStoreError, JsonFieldMap] =
+      for
+        value <- requireField(fields, from, summary)
+      yield fields.removed(from).updated(to, value)
+
+  final case class ChangeField(name: String, convert: Json => IO[EclipseStoreError, Json]) extends MigrationStep:
+    override val summary: String = s"change-field($name)"
+
+    override private[schema] def apply(fields: JsonFieldMap): IO[EclipseStoreError, JsonFieldMap] =
+      for
+        value   <- requireField(fields, name, summary)
+        updated <- convert(value).mapError(wrap(summary))
+      yield fields.updated(name, updated)
+
+  final case class SplitField(name: String, targets: Chunk[(String, Json => IO[EclipseStoreError, Json])])
+    extends MigrationStep:
+    override val summary: String =
+      s"split-field($name->${targets.map(_._1).mkString(",")})"
+
+    override private[schema] def apply(fields: JsonFieldMap): IO[EclipseStoreError, JsonFieldMap] =
+      for
+        source  <- requireField(fields, name, summary)
+        created <- ZIO.foreach(targets) {
+                     case (targetName, convert) =>
+                       convert(source).mapBoth(wrap(summary), targetName -> _)
+                   }
+      yield created.foldLeft(fields.removed(name)) {
+        case (acc, (targetName, value)) =>
+          acc.updated(targetName, value)
+      }
+
+  final case class MergeFields(
+    names: Chunk[String],
+    to: String,
+    combine: Chunk[Json] => IO[EclipseStoreError, Json],
+  ) extends MigrationStep:
+    override val summary: String =
+      s"merge-fields(${names.mkString(",")}->$to)"
+
+    override private[schema] def apply(fields: JsonFieldMap): IO[EclipseStoreError, JsonFieldMap] =
+      for
+        values <- ZIO.foreach(names)(requireField(fields, _, summary))
+        merged <- combine(values).mapError(wrap(summary))
+      yield names.foldLeft(fields)((acc, fieldName) => acc.removed(fieldName)).updated(to, merged)
+
+  private def requireField(fields: JsonFieldMap, name: String, step: String): IO[EclipseStoreError, Json] =
+    fields.get(name) match
+      case Some(value) => ZIO.succeed(value)
+      case None        => missingField(name, step)
+
+  private def missingField(name: String, step: String): IO[EclipseStoreError, Nothing] =
+    ZIO.fail(EclipseStoreError.MigrationError(s"Migration step $step requires field '$name'", None))
+
+  private def wrap(step: String)(error: EclipseStoreError): EclipseStoreError =
+    EclipseStoreError.MigrationError(s"Migration step $step failed: $error", None)
+
+final case class MigrationPlan[Old, New](
+  migration: Migration[Old, New],
+  oldSchema: Schema[Old],
+  newSchema: Schema[New],
+):
+  def steps: Chunk[MigrationStep] =
+    migration.steps
+
+  def validate: IO[EclipseStoreError, Unit] =
+    ZIO.foreachDiscard(validationErrors)(error => ZIO.fail(error))
+
+  def migrate(value: Old): IO[EclipseStoreError, New] =
+    for
+      payload <- encodeOld(value)
+      result  <- migratePayload(payload)
+    yield result
+
+  def migratePayload(payload: String): IO[EclipseStoreError, New] =
+    for
+      _        <- validate
+      fieldMap <- decodeFieldMap(payload)
+      migrated <- ZIO.foldLeft(steps)(fieldMap)((current, step) => step.apply(current))
+      result   <- decodeNew(migrated.toJson)
+    yield result
+
+  private def validationErrors: Chunk[EclipseStoreError] =
+    val oldFields        = SchemaIntrospection.topLevelFields(oldSchema)
+    val newFields        = SchemaIntrospection.topLevelFields(newSchema)
+    val stepCoverage     = ValidationCoverage.from(steps)
+    val untouchedCommon  = oldFields.keySet.intersect(newFields.keySet)
+    val incompatibleSame = Chunk.fromIterable(untouchedCommon.collect {
+      case name
+           if oldFields(name) != newFields(name) && !stepCoverage.changedFields.contains(name) =>
+        EclipseStoreError.IncompatibleSchemaError(
+          s"Field '$name' changed type without a converter in the migration plan",
+          None,
+        )
+    })
+    val missingNewFields =
+      Chunk.fromIterable(newFields.keySet.diff(oldFields.keySet).diff(stepCoverage.createdFields)).map(name =>
+        EclipseStoreError.IncompatibleSchemaError(
+          s"New field '$name' is not covered by add/rename/split/merge in the migration plan",
+          None,
+        )
+      )
+    val removedOldFields =
+      Chunk.fromIterable(oldFields.keySet.diff(newFields.keySet).diff(stepCoverage.consumedFields)).map(name =>
+        EclipseStoreError.IncompatibleSchemaError(
+          s"Old field '$name' would be dropped without an explicit remove/rename/split/merge step",
+          None,
+        )
+      )
+    val invalidSteps     = steps.flatMap(validateStep(_, oldFields, newFields))
+    incompatibleSame ++ missingNewFields ++ removedOldFields ++ invalidSteps
+
+  private def validateStep(
+    step: MigrationStep,
+    oldFields: Map[String, String],
+    newFields: Map[String, String],
+  ): Chunk[EclipseStoreError] =
+    step match
+      case MigrationStep.AddField(name, _) if !newFields.contains(name)                                 =>
+        Chunk(EclipseStoreError.IncompatibleSchemaError(
+          s"Add-field target '$name' is absent from the new schema",
+          None,
+        ))
+      case MigrationStep.RemoveField(name) if !oldFields.contains(name)                                 =>
+        Chunk(EclipseStoreError.IncompatibleSchemaError(
+          s"Remove-field source '$name' is absent from the old schema",
+          None,
+        ))
+      case MigrationStep.RenameField(from, to)                                                          =>
+        Chunk(
+          Option.when(!oldFields.contains(from))(
+            EclipseStoreError.IncompatibleSchemaError(s"Rename source '$from' is absent from the old schema", None)
+          ),
+          Option.when(!newFields.contains(to))(
+            EclipseStoreError.IncompatibleSchemaError(s"Rename target '$to' is absent from the new schema", None)
+          ),
+          Option.when(oldFields.get(from).exists(oldField => newFields.get(to).exists(_ != oldField)))(
+            EclipseStoreError.IncompatibleSchemaError(
+              s"Rename '$from' -> '$to' changes the field type; use changeField or split/merge instead",
+              None,
+            )
+          ),
+        ).flatten
+      case MigrationStep.ChangeField(name, _) if !oldFields.contains(name) || !newFields.contains(name) =>
+        Chunk(
+          EclipseStoreError.IncompatibleSchemaError(
+            s"Change-field '$name' requires the field to exist in both old and new schemas",
+            None,
+          )
+        )
+      case MigrationStep.SplitField(name, targets)                                                      =>
+        val targetErrors = targets.collect {
+          case (targetName, _) if !newFields.contains(targetName) =>
+            EclipseStoreError.IncompatibleSchemaError(
+              s"Split-field target '$targetName' is absent from the new schema",
+              None,
+            )
+        }
+        val sourceErrors =
+          if oldFields.contains(name) then Chunk.empty
+          else
+            Chunk(EclipseStoreError.IncompatibleSchemaError(
+              s"Split-field source '$name' is absent from the old schema",
+              None,
+            ))
+        sourceErrors ++ targetErrors
+      case MigrationStep.MergeFields(names, to, _)                                                      =>
+        val sourceErrors = names.collect {
+          case name if !oldFields.contains(name) =>
+            EclipseStoreError.IncompatibleSchemaError(
+              s"Merge-field source '$name' is absent from the old schema",
+              None,
+            )
+        }
+        val targetErrors =
+          if newFields.contains(to) then Chunk.empty
+          else
+            Chunk(EclipseStoreError.IncompatibleSchemaError(
+              s"Merge-field target '$to' is absent from the new schema",
+              None,
+            ))
+        sourceErrors ++ targetErrors
+      case _                                                                                            =>
+        Chunk.empty
+
+  private def encodeOld(value: Old): IO[EclipseStoreError, String] =
+    ZIO
+      .attempt(JsonCodec.jsonCodec(oldSchema).encodeJson(value, None).toString)
+      .mapError(cause => EclipseStoreError.MigrationError("Failed to encode source value for migration", Some(cause)))
+
+  private def decodeFieldMap(payload: String): IO[EclipseStoreError, JsonFieldMap] =
+    ZIO
+      .fromEither(payload.fromJson[JsonFieldMap])
+      .mapError(message =>
+        EclipseStoreError.MigrationError(s"Failed to decode source payload for migration: $message", None)
+      )
+
+  private def decodeNew(payload: String): IO[EclipseStoreError, New] =
+    ZIO
+      .attempt(JsonCodec.jsonCodec(newSchema).decodeJson(payload))
+      .mapError(cause => EclipseStoreError.MigrationError("Failed to decode migrated payload", Some(cause)))
+      .flatMap {
+        case Right(value) => ZIO.succeed(value)
+        case Left(error)  =>
+          ZIO.fail(EclipseStoreError.MigrationError(s"Failed to decode migrated payload: $error", None))
+      }
+
+private object SchemaIntrospection:
+  def topLevelFields[A](schema: Schema[A]): Map[String, String] =
+    schema match
+      case record: Schema.Record[A] =>
+        record.fields.map(field => field.name -> stableShape(field.schema.asInstanceOf[Schema[?]])).toMap
+      case _                        =>
+        Map.empty
+
+  private def stableShape(schema: Schema[?]): String =
+    schema.ast.toString
+
+final private case class ValidationCoverage(
+  createdFields: Set[String],
+  consumedFields: Set[String],
+  changedFields: Set[String],
+)
+
+private object ValidationCoverage:
+  val empty: ValidationCoverage =
+    ValidationCoverage(Set.empty, Set.empty, Set.empty)
+
+  def from(steps: Chunk[MigrationStep]): ValidationCoverage =
+    steps.foldLeft(empty) {
+      case (acc, MigrationStep.AddField(name, _))         =>
+        acc.copy(createdFields = acc.createdFields + name)
+      case (acc, MigrationStep.RemoveField(name))         =>
+        acc.copy(consumedFields = acc.consumedFields + name)
+      case (acc, MigrationStep.RenameField(from, to))     =>
+        acc.copy(
+          createdFields = acc.createdFields + to,
+          consumedFields = acc.consumedFields + from,
+        )
+      case (acc, MigrationStep.ChangeField(name, _))      =>
+        acc.copy(changedFields = acc.changedFields + name)
+      case (acc, MigrationStep.SplitField(from, targets)) =>
+        acc.copy(
+          createdFields = acc.createdFields ++ targets.map(_._1),
+          consumedFields = acc.consumedFields + from,
+        )
+      case (acc, MigrationStep.MergeFields(from, to, _))  =>
+        acc.copy(
+          createdFields = acc.createdFields + to,
+          consumedFields = acc.consumedFields ++ from,
+        )
+    }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/SchemaIntrospection.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/SchemaIntrospection.scala
@@ -1,0 +1,19 @@
+package io.github.riccardomerolla.zio.eclipsestore.schema
+
+import scala.util.hashing.MurmurHash3
+
+import zio.schema.Schema
+
+object SchemaIntrospection:
+  def topLevelFields[A](schema: Schema[A]): Map[String, String] =
+    schema match
+      case record: Schema.Record[A] =>
+        record.fields.map(field => field.name -> stableShape(field.schema.asInstanceOf[Schema[?]])).toMap
+      case _                        =>
+        Map.empty
+
+  def stableShape[A](schema: Schema[A]): String =
+    schema.ast.toString
+
+  def fingerprint[A](schema: Schema[A]): String =
+    java.lang.Integer.toUnsignedString(MurmurHash3.stringHash(stableShape(schema)), 16)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/SchemaSerializer.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/SchemaSerializer.scala
@@ -1,0 +1,86 @@
+package io.github.riccardomerolla.zio.eclipsestore.schema
+
+import scala.reflect.ClassTag
+
+import zio.*
+import zio.schema.Schema
+import zio.schema.codec.JsonCodec
+
+import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfig
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** Public Scala-native serialization boundary for schema-driven persistence. */
+trait SchemaSerializer:
+  def encode[A: Schema](value: A): IO[EclipseStoreError, String]
+  def decode[A: Schema](payload: String): IO[EclipseStoreError, A]
+  def typeHandler[A: Schema: ClassTag]: IO[EclipseStoreError, TypeHandler[A]]
+  def handlersFor[A: Schema: ClassTag]: IO[EclipseStoreError, Chunk[TypeHandler[?]]]
+  def register[A: Schema: ClassTag](config: EclipseStoreConfig): IO[EclipseStoreError, EclipseStoreConfig]
+
+final case class SchemaSerializerLive() extends SchemaSerializer:
+  override def encode[A: Schema](value: A): IO[EclipseStoreError, String] =
+    ZIO
+      .attempt(JsonCodec.jsonCodec(summon[Schema[A]]).encodeJson(value, None).toString)
+      .mapError(cause => EclipseStoreError.QueryError("Failed to encode schema value", Some(cause)))
+
+  override def decode[A: Schema](payload: String): IO[EclipseStoreError, A] =
+    ZIO
+      .attempt(JsonCodec.jsonCodec(summon[Schema[A]]).decodeJson(payload))
+      .mapError(cause => EclipseStoreError.QueryError("Failed to decode schema payload", Some(cause)))
+      .flatMap {
+        case Right(value) => ZIO.succeed(value)
+        case Left(error)  => ZIO.fail(EclipseStoreError.QueryError(s"Failed to decode schema payload: $error", None))
+      }
+
+  override def typeHandler[A: Schema: ClassTag]: IO[EclipseStoreError, TypeHandler[A]] =
+    ZIO
+      .attempt(TypeHandler.fromBinary(SchemaBinaryCodec.handler(Schema[A])))
+      .mapError(cause => EclipseStoreError.InitializationError("Failed to derive schema type handler", Some(cause)))
+
+  override def handlersFor[A: Schema: ClassTag]: IO[EclipseStoreError, Chunk[TypeHandler[?]]] =
+    ZIO
+      .attempt(SchemaBinaryCodec.handlers(Schema[A]).map(TypeHandler.fromUntyped))
+      .mapError(cause => EclipseStoreError.InitializationError("Failed to derive schema handlers", Some(cause)))
+
+  override def register[A: Schema: ClassTag](config: EclipseStoreConfig): IO[EclipseStoreError, EclipseStoreConfig] =
+    ZIO.attempt(SchemaSerializer.registerInConfig[A](config)).mapError(cause =>
+      EclipseStoreError.InitializationError("Failed to register schema handlers", Some(cause))
+    )
+
+object SchemaSerializer:
+  import org.eclipse.serializer.persistence.binary.types.Binary
+  import org.eclipse.serializer.persistence.types.PersistenceTypeHandler
+
+  val live: ULayer[SchemaSerializer] =
+    ZLayer.succeed(SchemaSerializerLive())
+
+  private[schema] def registerInConfig[A: Schema: ClassTag](config: EclipseStoreConfig): EclipseStoreConfig =
+    val handlers = SchemaBinaryCodec.handlers(Schema[A]).map(TypeHandler.fromUntyped)
+    val merged   = config.customTypeHandlers ++ handlers.map(_.persistenceHandler)
+    config.copy(customTypeHandlers = dedupeByRuntimeClass(merged))
+
+  private def dedupeByRuntimeClass(
+    handlers: Chunk[PersistenceTypeHandler[Binary, ?]]
+  ): Chunk[PersistenceTypeHandler[Binary, ?]] =
+    handlers.foldLeft((Chunk.empty[PersistenceTypeHandler[Binary, ?]], Set.empty[Class[?]])) {
+      case ((acc, seen), handler) =>
+        val runtimeClass = handler.`type`()
+        if seen.contains(runtimeClass) then (acc, seen)
+        else (acc :+ handler, seen + runtimeClass)
+    }._1
+
+  def encode[A: Schema](value: A): ZIO[SchemaSerializer, EclipseStoreError, String] =
+    ZIO.serviceWithZIO[SchemaSerializer](_.encode(value))
+
+  def decode[A: Schema](payload: String): ZIO[SchemaSerializer, EclipseStoreError, A] =
+    ZIO.serviceWithZIO[SchemaSerializer](_.decode(payload))
+
+  def typeHandler[A: Schema: ClassTag]: ZIO[SchemaSerializer, EclipseStoreError, TypeHandler[A]] =
+    ZIO.serviceWithZIO[SchemaSerializer](_.typeHandler[A])
+
+  def handlersFor[A: Schema: ClassTag]: ZIO[SchemaSerializer, EclipseStoreError, Chunk[TypeHandler[?]]] =
+    ZIO.serviceWithZIO[SchemaSerializer](_.handlersFor[A])
+
+  def register[A: Schema: ClassTag](config: EclipseStoreConfig)
+    : ZIO[SchemaSerializer, EclipseStoreError, EclipseStoreConfig] =
+    ZIO.serviceWithZIO[SchemaSerializer](_.register[A](config))

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistence.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistence.scala
@@ -58,7 +58,7 @@ final case class IngestionReport[K, V](
   batches: Chunk[BatchReport],
 )
 
-private final case class BatchOutcome[K, V](
+final private case class BatchOutcome[K, V](
   committed: Int,
   skipped: Int,
   parked: Chunk[ParkedRecord[K, V]],
@@ -101,8 +101,9 @@ final case class StreamingPersistenceLive[Root: Schema](
     records
       .grouped(normalizedBatchSize)
       .zipWithIndex
-      .mapZIOPar(normalizedParallelism) { case (batch, index) =>
-        processBatch(batch, index, config)
+      .mapZIOPar(normalizedParallelism) {
+        case (batch, index) =>
+          processBatch(batch, index, config)
       }
       .runFold[IngestionReport[K, V]](IngestionReport[K, V](0, 0, 0, Chunk.empty, Chunk.empty)) {
         case (report, (attempted, outcome, batchReport)) =>
@@ -142,7 +143,7 @@ final case class StreamingPersistenceLive[Root: Schema](
     config: IngestionConfig,
   ): IO[EclipseStoreError, BatchOutcome[K, V]] =
     item match
-      case IngestionItem.Record(key, value)       =>
+      case IngestionItem.Record(key, value)        =>
         storeWithStrategy(StreamRecord(key, value), config.errorStrategy)
       case IngestionItem.Malformed(payload, error) =>
         malformedWithStrategy(payload, error, config.errorStrategy)
@@ -155,13 +156,13 @@ final case class StreamingPersistenceLive[Root: Schema](
       typedStore.store(record.key, record.value)
 
     strategy match
-      case ErrorStrategy.FailFast        =>
+      case ErrorStrategy.FailFast       =>
         persist.as(BatchOutcome(committed = 1, skipped = 0, parked = Chunk.empty))
-      case ErrorStrategy.Skip            =>
+      case ErrorStrategy.Skip           =>
         persist
           .as(BatchOutcome(committed = 1, skipped = 0, parked = Chunk.empty))
           .catchAll(_ => ZIO.succeed(BatchOutcome(committed = 0, skipped = 1, parked = Chunk.empty)))
-      case ErrorStrategy.Park            =>
+      case ErrorStrategy.Park           =>
         persist
           .as(BatchOutcome(committed = 1, skipped = 0, parked = Chunk.empty))
           .catchAll(error =>
@@ -174,7 +175,11 @@ final case class StreamingPersistenceLive[Root: Schema](
             )
           )
       case ErrorStrategy.Retry(retries) =>
-        persist.retry(Schedule.recurs(math.max(0, retries))).as(BatchOutcome(committed = 1, skipped = 0, parked = Chunk.empty))
+        persist.retry(Schedule.recurs(math.max(0, retries))).as(BatchOutcome(
+          committed = 1,
+          skipped = 0,
+          parked = Chunk.empty,
+        ))
 
   private def malformedWithStrategy[K, V](
     payload: String,
@@ -196,7 +201,8 @@ final case class StreamingPersistenceLive[Root: Schema](
         )
 
 object StreamingPersistence:
-  def live[Root: Tag: Schema](descriptor: RootDescriptor[Root]): ZLayer[TypedStore, Nothing, StreamingPersistence[Root]] =
+  def live[Root: Tag: Schema](descriptor: RootDescriptor[Root])
+    : ZLayer[TypedStore, Nothing, StreamingPersistence[Root]] =
     ZLayer.fromZIO {
       for
         typedStore <- ZIO.service[TypedStore]
@@ -213,7 +219,8 @@ object StreamingPersistence:
   ): ZIO[StreamingPersistence[Root], EclipseStoreError, IngestionReport[K, V]] =
     ZIO.serviceWithZIO[StreamingPersistence[Root]](_.ingest(records, config))
 
-  def extract[Root: Tag, V: Schema](predicate: V => Boolean): ZStream[StreamingPersistence[Root], EclipseStoreError, V] =
+  def extract[Root: Tag, V: Schema](predicate: V => Boolean)
+    : ZStream[StreamingPersistence[Root], EclipseStoreError, V] =
     ZStream.serviceWithStream[StreamingPersistence[Root]](_.extract(predicate))
 
   def extractBatches[Root: Tag, V: Schema](

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistence.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistence.scala
@@ -1,0 +1,223 @@
+package io.github.riccardomerolla.zio.eclipsestore.schema
+
+import zio.*
+import zio.schema.Schema
+import zio.stream.ZStream
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+trait StreamingPersistence[Root]:
+  def descriptor: RootDescriptor[Root]
+  def root: IO[EclipseStoreError, Root]
+  def ingest[K: Schema, V: Schema](
+    records: ZStream[Any, Nothing, IngestionItem[K, V]],
+    config: IngestionConfig = IngestionConfig(),
+  ): IO[EclipseStoreError, IngestionReport[K, V]]
+  def extract[V: Schema](predicate: V => Boolean): ZStream[Any, EclipseStoreError, V]
+  def extractBatches[V: Schema](
+    predicate: V => Boolean,
+    batchSize: Int,
+  ): ZStream[Any, EclipseStoreError, Chunk[V]]
+
+final case class StreamRecord[K, V](key: K, value: V)
+
+enum IngestionItem[+K, +V]:
+  case Record(key: K, value: V)
+  case Malformed(payload: String, error: EclipseStoreError)
+
+enum ErrorStrategy:
+  case FailFast
+  case Skip
+  case Park
+  case Retry(maxRetries: Int)
+
+final case class IngestionConfig(
+  batchSize: Int = 128,
+  parallelism: Int = 1,
+  errorStrategy: ErrorStrategy = ErrorStrategy.FailFast,
+)
+
+enum ParkedRecord[K, V]:
+  case Rejected(record: StreamRecord[K, V], error: EclipseStoreError)
+  case Malformed(payload: String, error: EclipseStoreError)
+
+final case class BatchReport(
+  batchIndex: Long,
+  attempted: Int,
+  committed: Int,
+  skipped: Int,
+  parked: Int,
+)
+
+final case class IngestionReport[K, V](
+  attempted: Int,
+  committed: Int,
+  skipped: Int,
+  parked: Chunk[ParkedRecord[K, V]],
+  batches: Chunk[BatchReport],
+)
+
+private final case class BatchOutcome[K, V](
+  committed: Int,
+  skipped: Int,
+  parked: Chunk[ParkedRecord[K, V]],
+):
+  def +(other: BatchOutcome[K, V]): BatchOutcome[K, V] =
+    BatchOutcome(
+      committed = committed + other.committed,
+      skipped = skipped + other.skipped,
+      parked = parked ++ other.parked,
+    )
+
+  def toReport(batchIndex: Long, attempted: Int): BatchReport =
+    BatchReport(
+      batchIndex = batchIndex,
+      attempted = attempted,
+      committed = committed,
+      skipped = skipped,
+      parked = parked.size,
+    )
+
+private object BatchOutcome:
+  def empty[K, V]: BatchOutcome[K, V] =
+    BatchOutcome(committed = 0, skipped = 0, parked = Chunk.empty)
+
+final case class StreamingPersistenceLive[Root: Schema](
+  descriptor: RootDescriptor[Root],
+  typedStore: TypedStore,
+  writeSemaphore: Semaphore,
+) extends StreamingPersistence[Root]:
+  override def root: IO[EclipseStoreError, Root] =
+    typedStore.typedRoot(descriptor)
+
+  override def ingest[K: Schema, V: Schema](
+    records: ZStream[Any, Nothing, IngestionItem[K, V]],
+    config: IngestionConfig,
+  ): IO[EclipseStoreError, IngestionReport[K, V]] =
+    val normalizedBatchSize   = math.max(1, config.batchSize)
+    val normalizedParallelism = math.max(1, config.parallelism)
+
+    records
+      .grouped(normalizedBatchSize)
+      .zipWithIndex
+      .mapZIOPar(normalizedParallelism) { case (batch, index) =>
+        processBatch(batch, index, config)
+      }
+      .runFold[IngestionReport[K, V]](IngestionReport[K, V](0, 0, 0, Chunk.empty, Chunk.empty)) {
+        case (report, (attempted, outcome, batchReport)) =>
+          report.copy(
+            attempted = report.attempted + attempted,
+            committed = report.committed + outcome.committed,
+            skipped = report.skipped + outcome.skipped,
+            parked = report.parked ++ outcome.parked,
+            batches = report.batches :+ batchReport,
+          )
+      }
+
+  override def extract[V: Schema](predicate: V => Boolean): ZStream[Any, EclipseStoreError, V] =
+    extractBatches(predicate, batchSize = 128).flatMap(ZStream.fromChunk)
+
+  override def extractBatches[V: Schema](
+    predicate: V => Boolean,
+    batchSize: Int,
+  ): ZStream[Any, EclipseStoreError, Chunk[V]] =
+    typedStore.streamAll[V].filter(predicate).grouped(math.max(1, batchSize))
+
+  private def processBatch[K: Schema, V: Schema](
+    batch: Chunk[IngestionItem[K, V]],
+    batchIndex: Long,
+    config: IngestionConfig,
+  ): IO[EclipseStoreError, (Int, BatchOutcome[K, V], BatchReport)] =
+    writeSemaphore.withPermit {
+      ZIO
+        .foldLeft(batch)(BatchOutcome.empty[K, V]) { (acc, item) =>
+          processItem(item, config).map(acc + _)
+        }
+        .map(outcome => (batch.size, outcome, outcome.toReport(batchIndex, batch.size)))
+    }
+
+  private def processItem[K: Schema, V: Schema](
+    item: IngestionItem[K, V],
+    config: IngestionConfig,
+  ): IO[EclipseStoreError, BatchOutcome[K, V]] =
+    item match
+      case IngestionItem.Record(key, value)       =>
+        storeWithStrategy(StreamRecord(key, value), config.errorStrategy)
+      case IngestionItem.Malformed(payload, error) =>
+        malformedWithStrategy(payload, error, config.errorStrategy)
+
+  private def storeWithStrategy[K: Schema, V: Schema](
+    record: StreamRecord[K, V],
+    strategy: ErrorStrategy,
+  ): IO[EclipseStoreError, BatchOutcome[K, V]] =
+    def persist: IO[EclipseStoreError, Unit] =
+      typedStore.store(record.key, record.value)
+
+    strategy match
+      case ErrorStrategy.FailFast        =>
+        persist.as(BatchOutcome(committed = 1, skipped = 0, parked = Chunk.empty))
+      case ErrorStrategy.Skip            =>
+        persist
+          .as(BatchOutcome(committed = 1, skipped = 0, parked = Chunk.empty))
+          .catchAll(_ => ZIO.succeed(BatchOutcome(committed = 0, skipped = 1, parked = Chunk.empty)))
+      case ErrorStrategy.Park            =>
+        persist
+          .as(BatchOutcome(committed = 1, skipped = 0, parked = Chunk.empty))
+          .catchAll(error =>
+            ZIO.succeed(
+              BatchOutcome(
+                committed = 0,
+                skipped = 0,
+                parked = Chunk.single(ParkedRecord.Rejected(record, error)),
+              )
+            )
+          )
+      case ErrorStrategy.Retry(retries) =>
+        persist.retry(Schedule.recurs(math.max(0, retries))).as(BatchOutcome(committed = 1, skipped = 0, parked = Chunk.empty))
+
+  private def malformedWithStrategy[K, V](
+    payload: String,
+    error: EclipseStoreError,
+    strategy: ErrorStrategy,
+  ): IO[EclipseStoreError, BatchOutcome[K, V]] =
+    strategy match
+      case ErrorStrategy.FailFast | ErrorStrategy.Retry(_) =>
+        ZIO.fail(error)
+      case ErrorStrategy.Skip                              =>
+        ZIO.succeed(BatchOutcome(committed = 0, skipped = 1, parked = Chunk.empty))
+      case ErrorStrategy.Park                              =>
+        ZIO.succeed(
+          BatchOutcome(
+            committed = 0,
+            skipped = 0,
+            parked = Chunk.single(ParkedRecord.Malformed(payload, error)),
+          )
+        )
+
+object StreamingPersistence:
+  def live[Root: Tag: Schema](descriptor: RootDescriptor[Root]): ZLayer[TypedStore, Nothing, StreamingPersistence[Root]] =
+    ZLayer.fromZIO {
+      for
+        typedStore <- ZIO.service[TypedStore]
+        semaphore  <- Semaphore.make(1)
+      yield StreamingPersistenceLive(descriptor, typedStore, semaphore)
+    }
+
+  def root[Root: Tag]: ZIO[StreamingPersistence[Root], EclipseStoreError, Root] =
+    ZIO.serviceWithZIO[StreamingPersistence[Root]](_.root)
+
+  def ingest[Root: Tag, K: Schema, V: Schema](
+    records: ZStream[Any, Nothing, IngestionItem[K, V]],
+    config: IngestionConfig = IngestionConfig(),
+  ): ZIO[StreamingPersistence[Root], EclipseStoreError, IngestionReport[K, V]] =
+    ZIO.serviceWithZIO[StreamingPersistence[Root]](_.ingest(records, config))
+
+  def extract[Root: Tag, V: Schema](predicate: V => Boolean): ZStream[StreamingPersistence[Root], EclipseStoreError, V] =
+    ZStream.serviceWithStream[StreamingPersistence[Root]](_.extract(predicate))
+
+  def extractBatches[Root: Tag, V: Schema](
+    predicate: V => Boolean,
+    batchSize: Int,
+  ): ZStream[StreamingPersistence[Root], EclipseStoreError, Chunk[V]] =
+    ZStream.serviceWithStream[StreamingPersistence[Root]](_.extractBatches(predicate, batchSize))

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/TypeHandler.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/TypeHandler.scala
@@ -1,0 +1,28 @@
+package io.github.riccardomerolla.zio.eclipsestore.schema
+
+import org.eclipse.serializer.persistence.binary.types.{ Binary, BinaryTypeHandler }
+import org.eclipse.serializer.persistence.types.PersistenceTypeHandler
+
+/** Scala-native wrapper around an EclipseStore binary type handler. */
+final case class TypeHandler[+A](
+  runtimeClass: Class[?],
+  typeId: Long,
+  underlying: BinaryTypeHandler[?],
+):
+  def persistenceHandler: PersistenceTypeHandler[Binary, ?] =
+    underlying
+
+object TypeHandler:
+  private[schema] def fromBinary[A](handler: BinaryTypeHandler[A]): TypeHandler[A] =
+    TypeHandler(
+      runtimeClass = handler.`type`(),
+      typeId = handler.typeId(),
+      underlying = handler,
+    )
+
+  private[schema] def fromUntyped(handler: BinaryTypeHandler[?]): TypeHandler[?] =
+    TypeHandler(
+      runtimeClass = handler.`type`(),
+      typeId = handler.typeId(),
+      underlying = handler,
+    )

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/TypedStore.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/schema/TypedStore.scala
@@ -140,9 +140,7 @@ object TypedStore:
   def handlersFor[K: Schema: ClassTag, V: Schema: ClassTag]
     : ZLayer[EclipseStoreConfig, Nothing, EclipseStoreConfig] =
     ZLayer.fromFunction { (config: EclipseStoreConfig) =>
-      val keyHandlers   = SchemaBinaryCodec.handlers(Schema[K])
-      val valueHandlers = SchemaBinaryCodec.handlers(Schema[V])
-      config.copy(customTypeHandlers = config.customTypeHandlers ++ keyHandlers ++ valueHandlers)
+      SchemaSerializer.registerInConfig[V](SchemaSerializer.registerInConfig[K](config))
     }
 
   def store[K: Schema, V: Schema](key: K, value: V): ZIO[TypedStore, EclipseStoreError, Unit] =

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/LocalRepo.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/LocalRepo.scala
@@ -1,0 +1,69 @@
+package io.github.riccardomerolla.zio.eclipsestore.service
+
+import zio.*
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** Additive CRUD helpers for immutable `Map`-backed roots.
+  *
+  * These helpers fit the NativeLocal whole-root update model and are intended for small local-first aggregates. They do
+  * not replace `TypedStore` or domain-specific repositories.
+  */
+trait LocalRepo[Key, Value]:
+  def get(key: Key): IO[EclipseStoreError, Option[Value]]
+  def upsert(key: Key, value: Value): IO[EclipseStoreError, Value]
+  def delete(key: Key): IO[EclipseStoreError, Option[Value]]
+  def list: IO[EclipseStoreError, Chunk[Value]]
+  def entries: IO[EclipseStoreError, Map[Key, Value]]
+
+final case class LocalRepoLive[Root, Key, Value](
+  store: ObjectStore[Root],
+  extract: Root => Map[Key, Value],
+  replace: (Root, Map[Key, Value]) => Root,
+) extends LocalRepo[Key, Value]:
+  override def get(key: Key): IO[EclipseStoreError, Option[Value]] =
+    store.load.map(root => extract(root).get(key))
+
+  override def upsert(key: Key, value: Value): IO[EclipseStoreError, Value] =
+    store.modify { root =>
+      val next = extract(root).updated(key, value)
+      ZIO.succeed((value, replace(root, next)))
+    }
+
+  override def delete(key: Key): IO[EclipseStoreError, Option[Value]] =
+    store.modify { root =>
+      val current = extract(root)
+      val removed = current.get(key)
+      ZIO.succeed((removed, replace(root, current - key)))
+    }
+
+  override def list: IO[EclipseStoreError, Chunk[Value]] =
+    store.load.map(root => Chunk.fromIterable(extract(root).values))
+
+  override def entries: IO[EclipseStoreError, Map[Key, Value]] =
+    store.load.map(extract)
+
+object LocalRepo:
+  def get[Key: Tag, Value: Tag](key: Key): ZIO[LocalRepo[Key, Value], EclipseStoreError, Option[Value]] =
+    ZIO.serviceWithZIO[LocalRepo[Key, Value]](_.get(key))
+
+  def upsert[Key: Tag, Value: Tag](key: Key, value: Value): ZIO[LocalRepo[Key, Value], EclipseStoreError, Value] =
+    ZIO.serviceWithZIO[LocalRepo[Key, Value]](_.upsert(key, value))
+
+  def delete[Key: Tag, Value: Tag](key: Key): ZIO[LocalRepo[Key, Value], EclipseStoreError, Option[Value]] =
+    ZIO.serviceWithZIO[LocalRepo[Key, Value]](_.delete(key))
+
+  def list[Key: Tag, Value: Tag]: ZIO[LocalRepo[Key, Value], EclipseStoreError, Chunk[Value]] =
+    ZIO.serviceWithZIO[LocalRepo[Key, Value]](_.list)
+
+  def entries[Key: Tag, Value: Tag]: ZIO[LocalRepo[Key, Value], EclipseStoreError, Map[Key, Value]] =
+    ZIO.serviceWithZIO[LocalRepo[Key, Value]](_.entries)
+
+  def fromMap[Root: Tag, Key: Tag, Value: Tag](
+    extract: Root => Map[Key, Value]
+  )(
+    replace: (Root, Map[Key, Value]) => Root
+  ): ZLayer[ObjectStore[Root], Nothing, LocalRepo[Key, Value]] =
+    ZLayer.fromFunction { (store: ObjectStore[Root]) =>
+      LocalRepoLive(store, extract, replace)
+    }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala
@@ -13,11 +13,15 @@ import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 final private case class NativeLocalState[Root](
   descriptor: RootDescriptor[Root],
   snapshotPath: Path,
+  serde: NativeLocalSerde,
+  migrationRegistry: NativeLocalSnapshotMigrationRegistry[Root],
   rootRef: Ref[Root],
   rootTRef: TRef[Root],
   statusRef: Ref[LifecycleStatus],
   gate: Semaphore,
-)(using val codec: SnapshotCodec[Root]
+)(using
+  val codec: SnapshotCodec[Root],
+  val schema: Schema[Root],
 ):
   def normalize(root: Root): IO[EclipseStoreError, Root] =
     ZIO
@@ -36,10 +40,19 @@ final private case class NativeLocalState[Root](
     }
 
   def snapshotCurrentUnsafe: IO[EclipseStoreError, Unit] =
-    rootRef.get.flatMap(root => SnapshotCodec.save(snapshotPath, root))
+    rootRef.get.flatMap(root => SnapshotCodec.saveEnveloped(snapshotPath, root, descriptor.id, serde))
 
   def loadSnapshot(default: => Root): IO[EclipseStoreError, Root] =
-    SnapshotCodec.loadOrElse(snapshotPath, default).flatMap(normalize)
+    loadSnapshotFrom(snapshotPath, default)
+
+  def loadSnapshotFrom(path: Path, default: => Root): IO[EclipseStoreError, Root] =
+    SnapshotCodec
+      .loadEnvelopedOrElse(path, descriptor.id, serde, default, migrationRegistry)
+      .flatMap { loaded =>
+        normalize(loaded.value).tap(root =>
+          ZIO.when(loaded.rewriteRequired)(SnapshotCodec.saveEnveloped(snapshotPath, root, descriptor.id, serde))
+        )
+      }
 
 final private case class NativeLocalObjectStore[Root](state: NativeLocalState[Root]) extends ObjectStore[Root]:
   override def descriptor: RootDescriptor[Root] =
@@ -111,7 +124,7 @@ final private case class NativeLocalStorageOps[Root](state: NativeLocalState[Roo
   override def restoreFrom(source: Path): IO[EclipseStoreError, LifecycleStatus] =
     state.gate.withPermit {
       for
-        restored <- SnapshotCodec.load(source)(using state.codec).flatMap(state.normalize)
+        restored <- state.loadSnapshotFrom(source, state.descriptor.initializer())
         _        <- state.rootRef.set(restored)
         _        <- state.rootTRef.set(restored).commit
         _        <- state.snapshotCurrentUnsafe
@@ -177,15 +190,22 @@ object NativeLocal:
     snapshotPath: Path,
     descriptor: RootDescriptor[Root],
     serde: NativeLocalSerde,
+    migrationRegistry: NativeLocalSnapshotMigrationRegistry[Root],
   ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root] & NativeLocalSTM[Root]] =
     given SnapshotCodec[Root] = SnapshotCodec.forSerde[Root](serde)
 
     ZLayer.scopedEnvironment {
       for
-        loaded    <- SnapshotCodec.loadOrElse(snapshotPath, descriptor.initializer())
+        loaded    <- SnapshotCodec.loadEnvelopedOrElse(
+                       snapshotPath,
+                       descriptor.id,
+                       serde,
+                       descriptor.initializer(),
+                       migrationRegistry,
+                     )
         initial   <- ZIO
                        .attempt {
-                         val migrated = descriptor.migrate(loaded)
+                         val migrated = descriptor.migrate(loaded.value)
                          descriptor.onLoad(migrated)
                          migrated
                        }
@@ -200,7 +220,8 @@ object NativeLocal:
         startedAt <- Clock.instant
         statusRef <- Ref.make[LifecycleStatus](LifecycleStatus.Running(startedAt))
         gate      <- Semaphore.make(1)
-        state      = NativeLocalState(descriptor, snapshotPath, rootRef, rootTRef, statusRef, gate)
+        state      = NativeLocalState(descriptor, snapshotPath, serde, migrationRegistry, rootRef, rootTRef, statusRef, gate)
+        _         <- ZIO.when(loaded.rewriteRequired)(SnapshotCodec.saveEnveloped(snapshotPath, initial, descriptor.id, serde))
         store      = NativeLocalObjectStore(state)
         ops        = NativeLocalStorageOps(state)
         stm        = NativeLocalSTMLive(state)
@@ -215,9 +236,10 @@ object NativeLocal:
     snapshotPath: Path,
     descriptor: RootDescriptor[Root],
     serde: NativeLocalSerde = NativeLocalSerde.Json,
+    migrationRegistry: NativeLocalSnapshotMigrationRegistry[Root] = NativeLocalSnapshotMigrationRegistry.none[Root],
   ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root]] =
     ZLayer.scopedEnvironment {
-      allServices(snapshotPath, descriptor, serde).build.map { env =>
+      allServices(snapshotPath, descriptor, serde, migrationRegistry).build.map { env =>
         ZEnvironment[ObjectStore[Root], StorageOps[Root]](
           env.get[ObjectStore[Root]],
           env.get[StorageOps[Root]],
@@ -229,16 +251,18 @@ object NativeLocal:
     snapshotPath: Path,
     descriptor: RootDescriptor[Root],
     serde: NativeLocalSerde = NativeLocalSerde.Json,
+    migrationRegistry: NativeLocalSnapshotMigrationRegistry[Root] = NativeLocalSnapshotMigrationRegistry.none[Root],
   ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root] & NativeLocalSTM[Root]] =
-    allServices(snapshotPath, descriptor, serde)
+    allServices(snapshotPath, descriptor, serde, migrationRegistry)
 
   def stm[Root: Tag: Schema](
     snapshotPath: Path,
     descriptor: RootDescriptor[Root],
     serde: NativeLocalSerde = NativeLocalSerde.Json,
+    migrationRegistry: NativeLocalSnapshotMigrationRegistry[Root] = NativeLocalSnapshotMigrationRegistry.none[Root],
   ): ZLayer[Any, EclipseStoreError, NativeLocalSTM[Root]] =
     ZLayer.scopedEnvironment {
-      allServices(snapshotPath, descriptor, serde).build.map { env =>
+      allServices(snapshotPath, descriptor, serde, migrationRegistry).build.map { env =>
         ZEnvironment[NativeLocalSTM[Root]](env.get[NativeLocalSTM[Root]])
       }
     }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala
@@ -6,6 +6,7 @@ import zio.*
 import zio.schema.Schema
 import zio.stm.TRef
 
+import io.github.riccardomerolla.zio.eclipsestore.config.NativeLocalSerde
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 
@@ -175,8 +176,9 @@ object NativeLocal:
   private def allServices[Root: Tag: Schema](
     snapshotPath: Path,
     descriptor: RootDescriptor[Root],
+    serde: NativeLocalSerde,
   ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root] & NativeLocalSTM[Root]] =
-    given SnapshotCodec[Root] = SnapshotCodec.json[Root]
+    given SnapshotCodec[Root] = SnapshotCodec.forSerde[Root](serde)
 
     ZLayer.scopedEnvironment {
       for
@@ -212,9 +214,10 @@ object NativeLocal:
   def live[Root: Tag: Schema](
     snapshotPath: Path,
     descriptor: RootDescriptor[Root],
+    serde: NativeLocalSerde = NativeLocalSerde.Json,
   ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root]] =
     ZLayer.scopedEnvironment {
-      allServices(snapshotPath, descriptor).build.map { env =>
+      allServices(snapshotPath, descriptor, serde).build.map { env =>
         ZEnvironment[ObjectStore[Root], StorageOps[Root]](
           env.get[ObjectStore[Root]],
           env.get[StorageOps[Root]],
@@ -225,15 +228,17 @@ object NativeLocal:
   def liveWithSTM[Root: Tag: Schema](
     snapshotPath: Path,
     descriptor: RootDescriptor[Root],
+    serde: NativeLocalSerde = NativeLocalSerde.Json,
   ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root] & NativeLocalSTM[Root]] =
-    allServices(snapshotPath, descriptor)
+    allServices(snapshotPath, descriptor, serde)
 
   def stm[Root: Tag: Schema](
     snapshotPath: Path,
     descriptor: RootDescriptor[Root],
+    serde: NativeLocalSerde = NativeLocalSerde.Json,
   ): ZLayer[Any, EclipseStoreError, NativeLocalSTM[Root]] =
     ZLayer.scopedEnvironment {
-      allServices(snapshotPath, descriptor).build.map { env =>
+      allServices(snapshotPath, descriptor, serde).build.map { env =>
         ZEnvironment[NativeLocalSTM[Root]](env.get[NativeLocalSTM[Root]])
       }
     }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala
@@ -4,6 +4,7 @@ import java.nio.file.Path
 
 import zio.*
 import zio.schema.Schema
+import zio.stm.TRef
 
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
@@ -12,6 +13,7 @@ final private case class NativeLocalState[Root](
   descriptor: RootDescriptor[Root],
   snapshotPath: Path,
   rootRef: Ref[Root],
+  rootTRef: TRef[Root],
   statusRef: Ref[LifecycleStatus],
   gate: Semaphore,
 )(using val codec: SnapshotCodec[Root]
@@ -68,6 +70,7 @@ final private case class NativeLocalObjectStore[Root](state: NativeLocalState[Ro
       for
         normalized <- state.normalize(root)
         _          <- state.rootRef.set(normalized)
+        _          <- state.rootTRef.set(normalized).commit
       yield ()
     }
 
@@ -78,6 +81,7 @@ final private case class NativeLocalObjectStore[Root](state: NativeLocalState[Ro
         (result, nextRoot) <- f(current)
         normalizedNextRoot <- state.normalize(nextRoot)
         _                  <- state.rootRef.set(normalizedNextRoot)
+        _                  <- state.rootTRef.set(normalizedNextRoot).commit
       yield result
     }
 
@@ -108,6 +112,7 @@ final private case class NativeLocalStorageOps[Root](state: NativeLocalState[Roo
       for
         restored <- SnapshotCodec.load(source)(using state.codec).flatMap(state.normalize)
         _        <- state.rootRef.set(restored)
+        _        <- state.rootTRef.set(restored).commit
         _        <- state.snapshotCurrentUnsafe
         now      <- Clock.instant
         _        <- state.statusRef.set(LifecycleStatus.Running(now))
@@ -121,6 +126,7 @@ final private case class NativeLocalStorageOps[Root](state: NativeLocalState[Roo
         _            <- state.statusRef.set(LifecycleStatus.Restarting(restartingAt))
         reloaded     <- state.loadSnapshot(state.descriptor.initializer())
         _            <- state.rootRef.set(reloaded)
+        _            <- state.rootTRef.set(reloaded).commit
         runningAt    <- Clock.instant
         _            <- state.statusRef.set(LifecycleStatus.Running(runningAt))
       yield LifecycleStatus.Running(runningAt)
@@ -146,11 +152,30 @@ final private case class NativeLocalStorageOps[Root](state: NativeLocalState[Roo
       .unit
       .forkScoped
 
+final private case class NativeLocalSTMLive[Root](state: NativeLocalState[Root]) extends NativeLocalSTM[Root]:
+  override def atomically[A](effect: TRef[Root] => zio.stm.STM[EclipseStoreError, A]): IO[EclipseStoreError, A] =
+    state.gate.withPermit {
+      for
+        current <- state.rootRef.get
+        _       <- state.rootTRef.set(current).commit
+        result  <- effect(state.rootTRef).commit
+        staged  <- state.rootTRef.get.commit
+        next    <- state.normalize(staged).catchAll { error =>
+                     state.rootTRef.set(current).commit *> ZIO.fail(error)
+                   }
+        _       <- state.rootTRef.set(next).commit
+        _       <- state.rootRef.set(next)
+      yield result
+    }
+
+  override def snapshot: UIO[Root] =
+    state.rootRef.get
+
 object NativeLocal:
-  def live[Root: Tag: Schema](
+  private def allServices[Root: Tag: Schema](
     snapshotPath: Path,
     descriptor: RootDescriptor[Root],
-  ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root]] =
+  ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root] & NativeLocalSTM[Root]] =
     given SnapshotCodec[Root] = SnapshotCodec.json[Root]
 
     ZLayer.scopedEnvironment {
@@ -169,14 +194,46 @@ object NativeLocal:
                          )
                        )
         rootRef   <- Ref.make(initial)
+        rootTRef  <- TRef.make(initial).commit
         startedAt <- Clock.instant
         statusRef <- Ref.make[LifecycleStatus](LifecycleStatus.Running(startedAt))
         gate      <- Semaphore.make(1)
-        state      = NativeLocalState(descriptor, snapshotPath, rootRef, statusRef, gate)
+        state      = NativeLocalState(descriptor, snapshotPath, rootRef, rootTRef, statusRef, gate)
         store      = NativeLocalObjectStore(state)
         ops        = NativeLocalStorageOps(state)
-      yield ZEnvironment[ObjectStore[Root], StorageOps[Root]](
+        stm        = NativeLocalSTMLive(state)
+      yield ZEnvironment[ObjectStore[Root], StorageOps[Root], NativeLocalSTM[Root]](
         store,
         ops,
+        stm,
       )
+    }
+
+  def live[Root: Tag: Schema](
+    snapshotPath: Path,
+    descriptor: RootDescriptor[Root],
+  ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root]] =
+    ZLayer.scopedEnvironment {
+      allServices(snapshotPath, descriptor).build.map { env =>
+        ZEnvironment[ObjectStore[Root], StorageOps[Root]](
+          env.get[ObjectStore[Root]],
+          env.get[StorageOps[Root]],
+        )
+      }
+    }
+
+  def liveWithSTM[Root: Tag: Schema](
+    snapshotPath: Path,
+    descriptor: RootDescriptor[Root],
+  ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root] & NativeLocalSTM[Root]] =
+    allServices(snapshotPath, descriptor)
+
+  def stm[Root: Tag: Schema](
+    snapshotPath: Path,
+    descriptor: RootDescriptor[Root],
+  ): ZLayer[Any, EclipseStoreError, NativeLocalSTM[Root]] =
+    ZLayer.scopedEnvironment {
+      allServices(snapshotPath, descriptor).build.map { env =>
+        ZEnvironment[NativeLocalSTM[Root]](env.get[NativeLocalSTM[Root]])
+      }
     }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocal.scala
@@ -1,0 +1,182 @@
+package io.github.riccardomerolla.zio.eclipsestore.service
+
+import java.nio.file.Path
+
+import zio.*
+import zio.schema.Schema
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+final private case class NativeLocalState[Root](
+  descriptor: RootDescriptor[Root],
+  snapshotPath: Path,
+  rootRef: Ref[Root],
+  statusRef: Ref[LifecycleStatus],
+  gate: Semaphore,
+)(using val codec: SnapshotCodec[Root]
+):
+  def normalize(root: Root): IO[EclipseStoreError, Root] =
+    ZIO
+      .attempt {
+        val migrated = descriptor.migrate(root)
+        descriptor.onLoad(migrated)
+        migrated
+      }
+      .mapError(cause =>
+        EclipseStoreError.ResourceError(s"Failed to prepare NativeLocal root ${descriptor.id}", Some(cause))
+      )
+
+  def snapshotCurrent: IO[EclipseStoreError, Unit] =
+    gate.withPermit {
+      snapshotCurrentUnsafe
+    }
+
+  def snapshotCurrentUnsafe: IO[EclipseStoreError, Unit] =
+    rootRef.get.flatMap(root => SnapshotCodec.save(snapshotPath, root))
+
+  def loadSnapshot(default: => Root): IO[EclipseStoreError, Root] =
+    SnapshotCodec.loadOrElse(snapshotPath, default).flatMap(normalize)
+
+final private case class NativeLocalObjectStore[Root](state: NativeLocalState[Root]) extends ObjectStore[Root]:
+  override def descriptor: RootDescriptor[Root] =
+    state.descriptor
+
+  override def load: IO[EclipseStoreError, Root] =
+    state.rootRef.get
+
+  override def storeSubgraph(subgraph: AnyRef): IO[EclipseStoreError, Unit] =
+    state.snapshotCurrent
+
+  override def storeRoot: IO[EclipseStoreError, Unit] =
+    state.snapshotCurrent
+
+  override def checkpoint: IO[EclipseStoreError, Unit] =
+    state.snapshotCurrent
+
+  override def transact[A](transaction: Transaction[Root, A]): IO[EclipseStoreError, A] =
+    state.gate.withPermit {
+      for
+        root   <- state.rootRef.get
+        result <- transaction.run(root)
+        _      <- state.snapshotCurrentUnsafe
+      yield result
+    }
+
+  override def replace(root: Root): IO[EclipseStoreError, Unit] =
+    state.gate.withPermit {
+      for
+        normalized <- state.normalize(root)
+        _          <- state.rootRef.set(normalized)
+      yield ()
+    }
+
+  override def modify[A](f: Root => IO[EclipseStoreError, (A, Root)]): IO[EclipseStoreError, A] =
+    state.gate.withPermit {
+      for
+        current            <- state.rootRef.get
+        (result, nextRoot) <- f(current)
+        normalizedNextRoot <- state.normalize(nextRoot)
+        _                  <- state.rootRef.set(normalizedNextRoot)
+      yield result
+    }
+
+final private case class NativeLocalStorageOps[Root](state: NativeLocalState[Root]) extends StorageOps[Root]:
+  override def descriptor: RootDescriptor[Root] =
+    state.descriptor
+
+  override def load: IO[EclipseStoreError, Root] =
+    state.rootRef.get
+
+  override def status: UIO[LifecycleStatus] =
+    state.statusRef.get
+
+  override def checkpoint: IO[EclipseStoreError, LifecycleStatus] =
+    state.snapshotCurrent *> status
+
+  override def backup(target: Path, includeConfig: Boolean = true): IO[EclipseStoreError, LifecycleStatus] =
+    state.snapshotCurrent *> SnapshotCodec.copy(state.snapshotPath, target) *> status
+
+  override def exportTo(target: Path): IO[EclipseStoreError, LifecycleStatus] =
+    state.snapshotCurrent *> SnapshotCodec.copy(state.snapshotPath, target) *> status
+
+  override def importFrom(source: Path): IO[EclipseStoreError, LifecycleStatus] =
+    restoreFrom(source)
+
+  override def restoreFrom(source: Path): IO[EclipseStoreError, LifecycleStatus] =
+    state.gate.withPermit {
+      for
+        restored <- SnapshotCodec.load(source)(using state.codec).flatMap(state.normalize)
+        _        <- state.rootRef.set(restored)
+        _        <- state.snapshotCurrentUnsafe
+        now      <- Clock.instant
+        _        <- state.statusRef.set(LifecycleStatus.Running(now))
+      yield LifecycleStatus.Running(now)
+    }
+
+  override def restart: IO[EclipseStoreError, LifecycleStatus] =
+    state.gate.withPermit {
+      for
+        restartingAt <- Clock.instant
+        _            <- state.statusRef.set(LifecycleStatus.Restarting(restartingAt))
+        reloaded     <- state.loadSnapshot(state.descriptor.initializer())
+        _            <- state.rootRef.set(reloaded)
+        runningAt    <- Clock.instant
+        _            <- state.statusRef.set(LifecycleStatus.Running(runningAt))
+      yield LifecycleStatus.Running(runningAt)
+    }
+
+  override def shutdown: IO[EclipseStoreError, LifecycleStatus] =
+    state.gate.withPermit {
+      for
+        shuttingDownAt <- Clock.instant
+        _              <- state.statusRef.set(LifecycleStatus.ShuttingDown(shuttingDownAt))
+        _              <- state.snapshotCurrentUnsafe
+        _              <- state.statusRef.set(LifecycleStatus.Stopped)
+      yield LifecycleStatus.Stopped
+    }
+
+  override def housekeep: IO[EclipseStoreError, LifecycleStatus] =
+    checkpoint
+
+  override def scheduleCheckpoints(schedule: Schedule[Any, Any, Any]): URIO[Scope, Fiber.Runtime[Nothing, Unit]] =
+    checkpoint
+      .ignore
+      .repeat(schedule)
+      .unit
+      .forkScoped
+
+object NativeLocal:
+  def live[Root: Tag: Schema](
+    snapshotPath: Path,
+    descriptor: RootDescriptor[Root],
+  ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root]] =
+    given SnapshotCodec[Root] = SnapshotCodec.json[Root]
+
+    ZLayer.scopedEnvironment {
+      for
+        loaded    <- SnapshotCodec.loadOrElse(snapshotPath, descriptor.initializer())
+        initial   <- ZIO
+                       .attempt {
+                         val migrated = descriptor.migrate(loaded)
+                         descriptor.onLoad(migrated)
+                         migrated
+                       }
+                       .mapError(cause =>
+                         EclipseStoreError.InitializationError(
+                           s"Failed to initialize NativeLocal root ${descriptor.id}",
+                           Some(cause),
+                         )
+                       )
+        rootRef   <- Ref.make(initial)
+        startedAt <- Clock.instant
+        statusRef <- Ref.make[LifecycleStatus](LifecycleStatus.Running(startedAt))
+        gate      <- Semaphore.make(1)
+        state      = NativeLocalState(descriptor, snapshotPath, rootRef, statusRef, gate)
+        store      = NativeLocalObjectStore(state)
+        ops        = NativeLocalStorageOps(state)
+      yield ZEnvironment[ObjectStore[Root], StorageOps[Root]](
+        store,
+        ops,
+      )
+    }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSTM.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSTM.scala
@@ -1,0 +1,23 @@
+package io.github.riccardomerolla.zio.eclipsestore.service
+
+import zio.*
+import zio.stm.{ STM, TRef }
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** Optional STM adapter for NativeLocal roots.
+  *
+  * This is additive. The primary backend contracts remain `ObjectStore` and `StorageOps`.
+  */
+trait NativeLocalSTM[Root]:
+  def atomically[A](effect: TRef[Root] => STM[EclipseStoreError, A]): IO[EclipseStoreError, A]
+  def snapshot: UIO[Root]
+
+object NativeLocalSTM:
+  def atomically[Root: Tag, A](
+    effect: TRef[Root] => STM[EclipseStoreError, A]
+  ): ZIO[NativeLocalSTM[Root], EclipseStoreError, A] =
+    ZIO.serviceWithZIO[NativeLocalSTM[Root]](_.atomically(effect))
+
+  def snapshot[Root: Tag]: URIO[NativeLocalSTM[Root], Root] =
+    ZIO.serviceWithZIO[NativeLocalSTM[Root]](_.snapshot)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSnapshotEnvelope.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSnapshotEnvelope.scala
@@ -1,0 +1,32 @@
+package io.github.riccardomerolla.zio.eclipsestore.service
+
+import zio.Chunk
+import zio.schema.{ DeriveSchema, Schema }
+
+import io.github.riccardomerolla.zio.eclipsestore.schema.SchemaIntrospection
+
+final case class NativeLocalSnapshotEnvelope(
+  formatVersion: Int,
+  rootId: String,
+  schemaFingerprint: String,
+  schemaVersion: Option[Int],
+  payload: Chunk[Byte],
+)
+
+object NativeLocalSnapshotEnvelope:
+  val CurrentFormatVersion: Int = 1
+
+  given Schema[NativeLocalSnapshotEnvelope] = DeriveSchema.gen[NativeLocalSnapshotEnvelope]
+
+  def current[Root: Schema](
+    rootId: String,
+    payload: Chunk[Byte],
+    schemaVersion: Option[Int] = None,
+  ): NativeLocalSnapshotEnvelope =
+    NativeLocalSnapshotEnvelope(
+      formatVersion = CurrentFormatVersion,
+      rootId = rootId,
+      schemaFingerprint = SchemaIntrospection.fingerprint(summon[Schema[Root]]),
+      schemaVersion = schemaVersion,
+      payload = payload,
+    )

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSnapshotMigration.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/NativeLocalSnapshotMigration.scala
@@ -1,0 +1,68 @@
+package io.github.riccardomerolla.zio.eclipsestore.service
+
+import zio.*
+import zio.schema.Schema
+
+import io.github.riccardomerolla.zio.eclipsestore.config.NativeLocalSerde
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.schema.{ DerivedMigrationPlan, MigrationPlan, SchemaIntrospection }
+
+trait NativeLocalSnapshotMigration[Root]:
+  def matches(envelope: NativeLocalSnapshotEnvelope): Boolean
+  def migrate(envelope: NativeLocalSnapshotEnvelope, serde: NativeLocalSerde): IO[EclipseStoreError, Root]
+
+final case class NativeLocalSnapshotMigrationRegistry[Root](entries: Chunk[NativeLocalSnapshotMigration[Root]]):
+  def migrateOrFail(envelope: NativeLocalSnapshotEnvelope, serde: NativeLocalSerde): IO[EclipseStoreError, Root] =
+    entries.find(_.matches(envelope)) match
+      case Some(entry) => entry.migrate(envelope, serde)
+      case None        =>
+        ZIO.fail(
+          EclipseStoreError.MigrationError(
+            s"No NativeLocal snapshot migration is registered for root '${envelope.rootId}' and fingerprint '${envelope.schemaFingerprint}'",
+            None,
+          )
+        )
+
+object NativeLocalSnapshotMigrationRegistry:
+  def none[Root]: NativeLocalSnapshotMigrationRegistry[Root] =
+    NativeLocalSnapshotMigrationRegistry(Chunk.empty)
+
+  def single[Root](entry: NativeLocalSnapshotMigration[Root]): NativeLocalSnapshotMigrationRegistry[Root] =
+    NativeLocalSnapshotMigrationRegistry(Chunk(entry))
+
+object NativeLocalSnapshotMigration:
+  def fromPlan[Old: Schema, Root](
+    rootId: String,
+    plan: MigrationPlan[Old, Root],
+    schemaVersion: Option[Int] = None,
+  ): NativeLocalSnapshotMigration[Root] =
+    fromFunction[Old, Root](rootId, schemaVersion) { old =>
+      plan.validate *> plan.migrate(old)
+    }
+
+  def fromDerived[Old: Schema, Root](
+    rootId: String,
+    plan: DerivedMigrationPlan[Old, Root],
+    schemaVersion: Option[Int] = None,
+  ): NativeLocalSnapshotMigration[Root] =
+    fromFunction[Old, Root](rootId, schemaVersion) { old =>
+      plan.validate *> plan.migrate(old)
+    }
+
+  def fromFunction[Old: Schema, Root](
+    rootId: String,
+    schemaVersion: Option[Int] = None,
+  )(
+    f: Old => IO[EclipseStoreError, Root]
+  ): NativeLocalSnapshotMigration[Root] =
+    new NativeLocalSnapshotMigration[Root]:
+      private val fromFingerprint = SchemaIntrospection.fingerprint(summon[Schema[Old]])
+
+      override def matches(envelope: NativeLocalSnapshotEnvelope): Boolean =
+        envelope.rootId == rootId &&
+        envelope.schemaFingerprint == fromFingerprint &&
+        schemaVersion.forall(expected => envelope.schemaVersion.contains(expected))
+
+      override def migrate(envelope: NativeLocalSnapshotEnvelope, serde: NativeLocalSerde)
+        : IO[EclipseStoreError, Root] =
+        SnapshotCodec.decodePayload[Old](envelope.payload, serde).flatMap(f)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/ObjectStore.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/ObjectStore.scala
@@ -1,0 +1,86 @@
+package io.github.riccardomerolla.zio.eclipsestore.service
+
+import zio.*
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** Typed access to a single rooted object graph.
+  *
+  * This service wraps the lower-level `EclipseStoreService` with a root-focused API so applications can work against a
+  * typed root instead of treating EclipseStore as a key-value store.
+  */
+trait ObjectStore[Root]:
+  def descriptor: RootDescriptor[Root]
+  def load: IO[EclipseStoreError, Root]
+  def storeSubgraph(subgraph: AnyRef): IO[EclipseStoreError, Unit]
+  def storeRoot: IO[EclipseStoreError, Unit]
+  def checkpoint: IO[EclipseStoreError, Unit]
+  def transact[A](transaction: Transaction[Root, A]): IO[EclipseStoreError, A]
+
+final case class Transaction[-Root, +A](run: Root => IO[EclipseStoreError, A]):
+  def map[B](f: A => B): Transaction[Root, B] =
+    Transaction(root => run(root).map(f))
+
+  def flatMap[Root1 <: Root, B](f: A => Transaction[Root1, B]): Transaction[Root1, B] =
+    Transaction(root => run(root).flatMap(a => f(a).run(root)))
+
+object Transaction:
+  def succeed[Root, A](value: => A): Transaction[Root, A] =
+    Transaction(_ => ZIO.succeed(value))
+
+  def fail[Root, A](error: EclipseStoreError): Transaction[Root, A] =
+    Transaction(_ => ZIO.fail(error))
+
+  def effect[Root, A](f: Root => IO[EclipseStoreError, A]): Transaction[Root, A] =
+    Transaction(f)
+
+object ObjectStore:
+  def live[Root: Tag](descriptor0: RootDescriptor[Root]): ZLayer[EclipseStoreService, Nothing, ObjectStore[Root]] =
+    ZLayer.fromZIO {
+      for
+        service <- ZIO.service[EclipseStoreService]
+        txSem   <- Semaphore.make(1)
+      yield ObjectStoreLive(descriptor0, service, txSem)
+    }
+
+  def load[Root: Tag]: ZIO[ObjectStore[Root], EclipseStoreError, Root] =
+    ZIO.serviceWithZIO[ObjectStore[Root]](_.load)
+
+  def storeSubgraph[Root: Tag](subgraph: AnyRef): ZIO[ObjectStore[Root], EclipseStoreError, Unit] =
+    ZIO.serviceWithZIO[ObjectStore[Root]](_.storeSubgraph(subgraph))
+
+  def storeRoot[Root: Tag]: ZIO[ObjectStore[Root], EclipseStoreError, Unit] =
+    ZIO.serviceWithZIO[ObjectStore[Root]](_.storeRoot)
+
+  def checkpoint[Root: Tag]: ZIO[ObjectStore[Root], EclipseStoreError, Unit] =
+    ZIO.serviceWithZIO[ObjectStore[Root]](_.checkpoint)
+
+  def transact[Root: Tag, A](transaction: Transaction[Root, A]): ZIO[ObjectStore[Root], EclipseStoreError, A] =
+    ZIO.serviceWithZIO[ObjectStore[Root]](_.transact(transaction))
+
+final case class ObjectStoreLive[Root](
+  descriptor: RootDescriptor[Root],
+  underlying: EclipseStoreService,
+  txSemaphore: Semaphore,
+) extends ObjectStore[Root]:
+  override def load: IO[EclipseStoreError, Root] =
+    underlying.root(descriptor)
+
+  override def storeSubgraph(subgraph: AnyRef): IO[EclipseStoreError, Unit] =
+    underlying.persist(subgraph) *> checkpoint
+
+  override def storeRoot: IO[EclipseStoreError, Unit] =
+    checkpoint
+
+  override def checkpoint: IO[EclipseStoreError, Unit] =
+    underlying.maintenance(LifecycleCommand.Checkpoint).unit
+
+  override def transact[A](transaction: Transaction[Root, A]): IO[EclipseStoreError, A] =
+    txSemaphore.withPermit {
+      for
+        root   <- load
+        result <- transaction.run(root)
+        _      <- checkpoint
+      yield result
+    }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/ObjectStore.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/ObjectStore.scala
@@ -13,6 +13,8 @@ import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 trait ObjectStore[Root]:
   def descriptor: RootDescriptor[Root]
   def load: IO[EclipseStoreError, Root]
+  def replace(root: Root): IO[EclipseStoreError, Unit]
+  def modify[A](f: Root => IO[EclipseStoreError, (A, Root)]): IO[EclipseStoreError, A]
   def storeSubgraph(subgraph: AnyRef): IO[EclipseStoreError, Unit]
   def storeRoot: IO[EclipseStoreError, Unit]
   def checkpoint: IO[EclipseStoreError, Unit]
@@ -50,6 +52,12 @@ object ObjectStore:
   def storeSubgraph[Root: Tag](subgraph: AnyRef): ZIO[ObjectStore[Root], EclipseStoreError, Unit] =
     ZIO.serviceWithZIO[ObjectStore[Root]](_.storeSubgraph(subgraph))
 
+  def replace[Root: Tag](root: Root): ZIO[ObjectStore[Root], EclipseStoreError, Unit] =
+    ZIO.serviceWithZIO[ObjectStore[Root]](_.replace(root))
+
+  def modify[Root: Tag, A](f: Root => IO[EclipseStoreError, (A, Root)]): ZIO[ObjectStore[Root], EclipseStoreError, A] =
+    ZIO.serviceWithZIO[ObjectStore[Root]](_.modify(f))
+
   def storeRoot[Root: Tag]: ZIO[ObjectStore[Root], EclipseStoreError, Unit] =
     ZIO.serviceWithZIO[ObjectStore[Root]](_.storeRoot)
 
@@ -66,6 +74,23 @@ final case class ObjectStoreLive[Root](
 ) extends ObjectStore[Root]:
   override def load: IO[EclipseStoreError, Root] =
     underlying.root(descriptor)
+
+  override def replace(root: Root): IO[EclipseStoreError, Unit] =
+    ZIO.fail(
+      EclipseStoreError.QueryError(
+        s"Whole-root replacement is not supported by the EclipseStore-backed ObjectStore for ${descriptor.id}",
+        None,
+      )
+    )
+
+  override def modify[A](f: Root => IO[EclipseStoreError, (A, Root)]): IO[EclipseStoreError, A] =
+    txSemaphore.withPermit {
+      for
+        current           <- load
+        (result, updated) <- f(current)
+        _                 <- replace(updated)
+      yield result
+    }
 
   override def storeSubgraph(subgraph: AnyRef): IO[EclipseStoreError, Unit] =
     underlying.persist(subgraph) *> checkpoint

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/SnapshotCodec.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/SnapshotCodec.scala
@@ -9,6 +9,7 @@ import zio.schema.codec.{ BinaryCodec, JsonCodec, ProtobufCodec }
 
 import io.github.riccardomerolla.zio.eclipsestore.config.NativeLocalSerde
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.schema.SchemaIntrospection
 
 /** Schema-driven whole-root snapshot codec used by the NativeLocal backend. */
 trait SnapshotCodec[A]:
@@ -39,6 +40,8 @@ final case class JsonSnapshotCodec[A: Schema]() extends SnapshotCodec[A]:
       }
 
 object SnapshotCodec:
+  final case class SnapshotLoadResult[A](value: A, rewriteRequired: Boolean)
+
   def json[A: Schema]: SnapshotCodec[A] =
     JsonSnapshotCodec[A]()
 
@@ -50,24 +53,30 @@ object SnapshotCodec:
       case NativeLocalSerde.Json     => json[A]
       case NativeLocalSerde.Protobuf => protobuf[A]
 
+  def encodePayload[A: Schema](value: A, serde: NativeLocalSerde): IO[EclipseStoreError, Chunk[Byte]] =
+    forSerde[A](serde).encode(value)
+
+  def decodePayload[A: Schema](bytes: Chunk[Byte], serde: NativeLocalSerde): IO[EclipseStoreError, A] =
+    forSerde[A](serde).decode(bytes)
+
+  def saveEnveloped[A: Schema](
+    path: Path,
+    value: A,
+    rootId: String,
+    serde: NativeLocalSerde,
+    schemaVersion: Option[Int] = None,
+  ): IO[EclipseStoreError, Unit] =
+    for
+      payload <- encodePayload(value, serde)
+      envelope = NativeLocalSnapshotEnvelope.current[A](rootId, payload, schemaVersion)
+      bytes   <- encodePayload(envelope, serde)
+      _       <- writeBytes(path, bytes)
+    yield ()
+
   def save[A](path: Path, value: A)(using codec: SnapshotCodec[A]): IO[EclipseStoreError, Unit] =
     for
       bytes <- codec.encode(value)
-      _     <- ZIO
-                 .attemptBlocking {
-                   Option(path.getParent).foreach(Files.createDirectories(_))
-                   Files.write(
-                     path,
-                     bytes.toArray,
-                     StandardOpenOption.CREATE,
-                     StandardOpenOption.TRUNCATE_EXISTING,
-                     StandardOpenOption.WRITE,
-                   )
-                 }
-                 .unit
-                 .mapError(cause =>
-                   EclipseStoreError.StorageError(s"Failed to write NativeLocal snapshot to $path", Some(cause))
-                 )
+      _     <- writeBytes(path, bytes)
     yield ()
 
   def load[A](path: Path)(using codec: SnapshotCodec[A]): IO[EclipseStoreError, A] =
@@ -96,6 +105,71 @@ object SnapshotCodec:
       .unit
       .mapError(cause =>
         EclipseStoreError.StorageError(s"Failed to copy NativeLocal snapshot from $source to $target", Some(cause))
+      )
+
+  def loadEnvelopedOrElse[A: Schema](
+    path: Path,
+    rootId: String,
+    serde: NativeLocalSerde,
+    orElse: => A,
+    migrationRegistry: NativeLocalSnapshotMigrationRegistry[A] = NativeLocalSnapshotMigrationRegistry.none[A],
+  ): IO[EclipseStoreError, SnapshotLoadResult[A]] =
+    ZIO
+      .attemptBlocking(Files.exists(path))
+      .mapError(cause =>
+        EclipseStoreError.StorageError(s"Failed to inspect NativeLocal snapshot path $path", Some(cause))
+      )
+      .flatMap {
+        case false => ZIO.succeed(SnapshotLoadResult(orElse, rewriteRequired = false))
+        case true  =>
+          for
+            bytes           <- ZIO
+                                 .attemptBlocking(Chunk.fromArray(Files.readAllBytes(path)))
+                                 .mapError(cause =>
+                                   EclipseStoreError.StorageError(
+                                     s"Failed to read NativeLocal snapshot from $path",
+                                     Some(cause),
+                                   )
+                                 )
+            envelopeAttempt <- decodePayload[NativeLocalSnapshotEnvelope](bytes, serde).either
+            loaded          <- envelopeAttempt match
+                                 case Right(envelope) =>
+                                   if envelope.rootId != rootId then
+                                     ZIO.fail(
+                                       EclipseStoreError.IncompatibleSchemaError(
+                                         s"NativeLocal snapshot root id '${envelope.rootId}' does not match expected root '$rootId'",
+                                         None,
+                                       )
+                                     )
+                                   else if envelope.schemaFingerprint == SchemaIntrospection.fingerprint(summon[Schema[A]]) then
+                                     decodePayload[A](
+                                       envelope.payload,
+                                       serde,
+                                     ).map(SnapshotLoadResult(_, rewriteRequired = false))
+                                   else
+                                     migrationRegistry
+                                       .migrateOrFail(envelope, serde)
+                                       .map(SnapshotLoadResult(_, rewriteRequired = true))
+                                 case Left(_)         =>
+                                   decodePayload[A](bytes, serde).map(SnapshotLoadResult(_, rewriteRequired = true))
+          yield loaded
+      }
+
+  private def writeBytes(path: Path, bytes: Chunk[Byte]): IO[EclipseStoreError, Unit] =
+    ZIO
+      .attemptBlocking {
+        Option(path.getParent).foreach(Files.createDirectories(_))
+        Files.write(
+          path,
+          bytes.toArray,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING,
+          StandardOpenOption.WRITE,
+        )
+      }
+      .unit
+      .mapError(cause =>
+        EclipseStoreError.StorageError(s"Failed to write NativeLocal snapshot to $path", Some(cause))
       )
 
 final case class ProtobufSnapshotCodec[A: Schema]() extends SnapshotCodec[A]:

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/SnapshotCodec.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/SnapshotCodec.scala
@@ -1,0 +1,90 @@
+package io.github.riccardomerolla.zio.eclipsestore.service
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path, StandardCopyOption, StandardOpenOption }
+
+import zio.*
+import zio.schema.Schema
+import zio.schema.codec.JsonCodec
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** Schema-driven whole-root snapshot codec used by the NativeLocal backend. */
+trait SnapshotCodec[A]:
+  def encode(value: A): IO[EclipseStoreError, Chunk[Byte]]
+  def decode(bytes: Chunk[Byte]): IO[EclipseStoreError, A]
+
+final case class JsonSnapshotCodec[A: Schema]() extends SnapshotCodec[A]:
+  private val codec = JsonCodec.jsonCodec(summon[Schema[A]])
+
+  override def encode(value: A): IO[EclipseStoreError, Chunk[Byte]] =
+    ZIO
+      .attempt(Chunk.fromArray(codec.encodeJson(value, None).toString.getBytes(StandardCharsets.UTF_8)))
+      .mapError(cause => EclipseStoreError.StorageError("Failed to encode NativeLocal snapshot", Some(cause)))
+
+  override def decode(bytes: Chunk[Byte]): IO[EclipseStoreError, A] =
+    ZIO
+      .attempt(new String(bytes.toArray, StandardCharsets.UTF_8))
+      .mapError(cause => EclipseStoreError.StorageError("Failed to read NativeLocal snapshot bytes", Some(cause)))
+      .flatMap { payload =>
+        ZIO
+          .fromEither(codec.decodeJson(payload))
+          .mapError(error =>
+            EclipseStoreError.IncompatibleSchemaError(
+              s"Failed to decode NativeLocal snapshot payload: $error",
+              None,
+            )
+          )
+      }
+
+object SnapshotCodec:
+  def json[A: Schema]: SnapshotCodec[A] =
+    JsonSnapshotCodec[A]()
+
+  def save[A](path: Path, value: A)(using codec: SnapshotCodec[A]): IO[EclipseStoreError, Unit] =
+    for
+      bytes <- codec.encode(value)
+      _     <- ZIO
+                 .attemptBlocking {
+                   Option(path.getParent).foreach(Files.createDirectories(_))
+                   Files.write(
+                     path,
+                     bytes.toArray,
+                     StandardOpenOption.CREATE,
+                     StandardOpenOption.TRUNCATE_EXISTING,
+                     StandardOpenOption.WRITE,
+                   )
+                 }
+                 .unit
+                 .mapError(cause =>
+                   EclipseStoreError.StorageError(s"Failed to write NativeLocal snapshot to $path", Some(cause))
+                 )
+    yield ()
+
+  def load[A](path: Path)(using codec: SnapshotCodec[A]): IO[EclipseStoreError, A] =
+    ZIO
+      .attemptBlocking(Chunk.fromArray(Files.readAllBytes(path)))
+      .mapError(cause => EclipseStoreError.StorageError(s"Failed to read NativeLocal snapshot from $path", Some(cause)))
+      .flatMap(codec.decode)
+
+  def loadOrElse[A](path: Path, orElse: => A)(using codec: SnapshotCodec[A]): IO[EclipseStoreError, A] =
+    ZIO
+      .attemptBlocking(Files.exists(path))
+      .mapError(cause =>
+        EclipseStoreError.StorageError(s"Failed to inspect NativeLocal snapshot path $path", Some(cause))
+      )
+      .flatMap {
+        case true  => load(path)
+        case false => ZIO.succeed(orElse)
+      }
+
+  def copy(source: Path, target: Path): IO[EclipseStoreError, Unit] =
+    ZIO
+      .attemptBlocking {
+        Option(target.getParent).foreach(Files.createDirectories(_))
+        Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING)
+      }
+      .unit
+      .mapError(cause =>
+        EclipseStoreError.StorageError(s"Failed to copy NativeLocal snapshot from $source to $target", Some(cause))
+      )

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/SnapshotCodec.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/SnapshotCodec.scala
@@ -5,8 +5,9 @@ import java.nio.file.{ Files, Path, StandardCopyOption, StandardOpenOption }
 
 import zio.*
 import zio.schema.Schema
-import zio.schema.codec.JsonCodec
+import zio.schema.codec.{ BinaryCodec, JsonCodec, ProtobufCodec }
 
+import io.github.riccardomerolla.zio.eclipsestore.config.NativeLocalSerde
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 
 /** Schema-driven whole-root snapshot codec used by the NativeLocal backend. */
@@ -40,6 +41,14 @@ final case class JsonSnapshotCodec[A: Schema]() extends SnapshotCodec[A]:
 object SnapshotCodec:
   def json[A: Schema]: SnapshotCodec[A] =
     JsonSnapshotCodec[A]()
+
+  def protobuf[A: Schema]: SnapshotCodec[A] =
+    ProtobufSnapshotCodec[A]()
+
+  def forSerde[A: Schema](serde: NativeLocalSerde): SnapshotCodec[A] =
+    serde match
+      case NativeLocalSerde.Json     => json[A]
+      case NativeLocalSerde.Protobuf => protobuf[A]
 
   def save[A](path: Path, value: A)(using codec: SnapshotCodec[A]): IO[EclipseStoreError, Unit] =
     for
@@ -87,4 +96,22 @@ object SnapshotCodec:
       .unit
       .mapError(cause =>
         EclipseStoreError.StorageError(s"Failed to copy NativeLocal snapshot from $source to $target", Some(cause))
+      )
+
+final case class ProtobufSnapshotCodec[A: Schema]() extends SnapshotCodec[A]:
+  private val codec: BinaryCodec[A] = ProtobufCodec.protobufCodec(summon[Schema[A]])
+
+  override def encode(value: A): IO[EclipseStoreError, Chunk[Byte]] =
+    ZIO
+      .attempt(codec.encode(value))
+      .mapError(cause => EclipseStoreError.StorageError("Failed to encode NativeLocal protobuf snapshot", Some(cause)))
+
+  override def decode(bytes: Chunk[Byte]): IO[EclipseStoreError, A] =
+    ZIO
+      .fromEither(codec.decode(bytes))
+      .mapError(error =>
+        EclipseStoreError.IncompatibleSchemaError(
+          s"Failed to decode NativeLocal protobuf snapshot payload: $error",
+          None,
+        )
       )

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala
@@ -5,8 +5,10 @@ import java.nio.file.Files
 import scala.jdk.CollectionConverters.*
 
 import zio.*
+import zio.schema.Schema
 
 import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, EclipseStoreConfig, StorageTarget }
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 
 /** Layer-managed backend selection for the EclipseStore substrate. */
@@ -41,6 +43,27 @@ object StorageBackend:
     configure: EclipseStoreConfig => EclipseStoreConfig = identity
   ): ZLayer[BackendConfig, EclipseStoreError, EclipseStoreService] =
     configLayer(configure) >>> EclipseStoreService.live >>> serializedService
+
+  def rootServices[Root: Tag: Schema](
+    descriptor: RootDescriptor[Root],
+    configure: EclipseStoreConfig => EclipseStoreConfig = identity,
+  ): ZLayer[BackendConfig, EclipseStoreError, ObjectStore[Root] & StorageOps[Root]] =
+    ZLayer.scopedEnvironment {
+      for
+        config       <- ZIO.service[BackendConfig]
+        selectedLayer = config match
+                          case nativeLocal: BackendConfig.NativeLocal =>
+                            NativeLocal.live(nativeLocal.snapshotPath, descriptor)
+                          case other                                  =>
+                            ZLayer.succeed(other) >>> service(
+                              configure
+                            ) >>> (ObjectStore.live(descriptor) ++ StorageOps.live(descriptor))
+        built        <- selectedLayer.build
+      yield ZEnvironment[ObjectStore[Root], StorageOps[Root]](
+        built.get[ObjectStore[Root]],
+        built.get[StorageOps[Root]],
+      )
+    }
 
   private val serializedService: ZLayer[EclipseStoreService, Nothing, EclipseStoreService] =
     ZLayer.fromZIO {

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala
@@ -1,0 +1,156 @@
+package io.github.riccardomerolla.zio.eclipsestore.service
+
+import java.nio.file.Files
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, EclipseStoreConfig, StorageTarget }
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** Layer-managed backend selection for the EclipseStore substrate. */
+trait StorageBackend:
+  def config: BackendConfig
+  def storageTarget: StorageTarget
+
+final case class StorageBackendLive(
+  config: BackendConfig,
+  storageTarget: StorageTarget,
+) extends StorageBackend
+
+object StorageBackend:
+  def live: ZLayer[BackendConfig, EclipseStoreError, StorageBackend] =
+    ZLayer.scoped {
+      for
+        config  <- ZIO.service[BackendConfig]
+        backend <- fromConfig(config)
+      yield backend
+    }
+
+  def configLayer(
+    configure: EclipseStoreConfig => EclipseStoreConfig = identity
+  ): ZLayer[BackendConfig, EclipseStoreError, EclipseStoreConfig] =
+    live >>> ZLayer.fromZIO {
+      for
+        backend <- ZIO.service[StorageBackend]
+      yield configure(EclipseStoreConfig(storageTarget = backend.storageTarget))
+    }
+
+  def service(
+    configure: EclipseStoreConfig => EclipseStoreConfig = identity
+  ): ZLayer[BackendConfig, EclipseStoreError, EclipseStoreService] =
+    configLayer(configure) >>> EclipseStoreService.live >>> serializedService
+
+  private val serializedService: ZLayer[EclipseStoreService, Nothing, EclipseStoreService] =
+    ZLayer.fromZIO {
+      for
+        underlying <- ZIO.service[EclipseStoreService]
+        semaphore  <- Semaphore.make(1)
+      yield new EclipseStoreService:
+        private def serialized[A](effect: => IO[EclipseStoreError, A]): IO[EclipseStoreError, A] =
+          semaphore.withPermit(effect)
+
+        override def execute[A](query: io.github.riccardomerolla.zio.eclipsestore.domain.Query[A])
+          : IO[EclipseStoreError, A] =
+          serialized(underlying.execute(query))
+
+        override def executeMany[A](queries: List[io.github.riccardomerolla.zio.eclipsestore.domain.Query[A]])
+          : IO[EclipseStoreError, List[A]] =
+          serialized(underlying.executeMany(queries))
+
+        override def get[K, V](key: K): IO[EclipseStoreError, Option[V]] =
+          serialized(underlying.get(key))
+
+        override def put[K, V](key: K, value: V): IO[EclipseStoreError, Unit] =
+          serialized(underlying.put(key, value))
+
+        override def putAll[K, V](entries: Iterable[(K, V)]): IO[EclipseStoreError, Unit] =
+          serialized(underlying.putAll(entries))
+
+        override def delete[K](key: K): IO[EclipseStoreError, Unit] =
+          serialized(underlying.delete(key))
+
+        override def getAll[V]: IO[EclipseStoreError, List[V]] =
+          serialized(underlying.getAll)
+
+        override def streamValues[V]: zio.stream.ZStream[Any, EclipseStoreError, V] =
+          zio.stream.ZStream.fromZIO(getAll[V]).flatMap(zio.stream.ZStream.fromIterable(_))
+
+        override def streamKeys[K]: zio.stream.ZStream[Any, EclipseStoreError, K] =
+          zio.stream.ZStream.fromZIO(serialized(
+            underlying.execute(io.github.riccardomerolla.zio.eclipsestore.domain.Query.GetAllKeys[K]())
+          ))
+            .flatMap(zio.stream.ZStream.fromIterable(_))
+
+        override def root[A](descriptor: io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor[A])
+          : IO[EclipseStoreError, A] =
+          serialized(underlying.root(descriptor))
+
+        override def persist[A](value: A): IO[EclipseStoreError, Unit] =
+          serialized(underlying.persist(value))
+
+        override def persistAll[A](values: Iterable[A]): IO[EclipseStoreError, Unit] =
+          serialized(underlying.persistAll(values))
+
+        override val reloadRoots: IO[EclipseStoreError, Unit] =
+          serialized(underlying.reloadRoots)
+
+        override def maintenance(command: LifecycleCommand): IO[EclipseStoreError, LifecycleStatus] =
+          serialized(underlying.maintenance(command))
+
+        override def status: UIO[LifecycleStatus] =
+          underlying.status
+
+        override def exportData(target: java.nio.file.Path): IO[EclipseStoreError, Unit] =
+          serialized(underlying.exportData(target))
+
+        override def importData(source: java.nio.file.Path): IO[EclipseStoreError, Unit] =
+          serialized(underlying.importData(source))
+    }
+
+  private def fromConfig(config: BackendConfig): ZIO[Scope, EclipseStoreError, StorageBackend] =
+    config match
+      case inMemory: BackendConfig.InMemory     =>
+        ZIO.acquireRelease(createTempDirectory(inMemory.prefix)) { path =>
+          deleteDirectory(path).ignore
+        }.map(path => StorageBackendLive(inMemory, StorageTarget.FileSystem(path)))
+      case fileSystem: BackendConfig.FileSystem =>
+        ensureDirectory(fileSystem.path).as(StorageBackendLive(fileSystem, StorageTarget.FileSystem(fileSystem.path)))
+      case mmap: BackendConfig.MemoryMapped     =>
+        ensureDirectory(mmap.path).as(StorageBackendLive(mmap, StorageTarget.MemoryMapped(mmap.path)))
+      case sqlite: BackendConfig.Sqlite         =>
+        ensureDirectory(sqlite.path).as(
+          StorageBackendLive(
+            sqlite,
+            StorageTarget.Sqlite(
+              path = sqlite.path,
+              storageName = sqlite.storageName,
+              connectionString = sqlite.connectionString,
+              busyTimeoutMs = sqlite.busyTimeoutMs,
+              cacheSizeKb = sqlite.cacheSizeKb,
+              pageSizeBytes = sqlite.pageSizeBytes,
+              journalMode = sqlite.journalMode,
+              synchronousMode = sqlite.synchronousMode,
+            ),
+          )
+        )
+      case other                                =>
+        ZIO.fromEither(other.toStorageTarget).map(target => StorageBackendLive(other, target))
+
+  private def createTempDirectory(prefix: String): ZIO[Any, EclipseStoreError, java.nio.file.Path] =
+    ZIO
+      .attempt(Files.createTempDirectory(prefix))
+      .mapError(cause => EclipseStoreError.BackendError(s"Failed to create backend directory for $prefix", Some(cause)))
+
+  private def ensureDirectory(path: java.nio.file.Path): ZIO[Any, EclipseStoreError, Unit] =
+    ZIO
+      .attemptBlocking(Files.createDirectories(path))
+      .unit
+      .mapError(cause => EclipseStoreError.BackendError(s"Failed to initialize backend path $path", Some(cause)))
+
+  private def deleteDirectory(path: java.nio.file.Path): Task[Unit] =
+    ZIO.attemptBlocking {
+      if Files.exists(path) then
+        Files.walk(path).iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists)
+    }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala
@@ -47,13 +47,14 @@ object StorageBackend:
   def rootServices[Root: Tag: Schema](
     descriptor: RootDescriptor[Root],
     configure: EclipseStoreConfig => EclipseStoreConfig = identity,
+    migrationRegistry: NativeLocalSnapshotMigrationRegistry[Root] = NativeLocalSnapshotMigrationRegistry.none[Root],
   ): ZLayer[BackendConfig, EclipseStoreError, ObjectStore[Root] & StorageOps[Root]] =
     ZLayer.scopedEnvironment {
       for
         config       <- ZIO.service[BackendConfig]
         selectedLayer = config match
                           case nativeLocal: BackendConfig.NativeLocal =>
-                            NativeLocal.live(nativeLocal.snapshotPath, descriptor, nativeLocal.serde)
+                            NativeLocal.live(nativeLocal.snapshotPath, descriptor, nativeLocal.serde, migrationRegistry)
                           case other                                  =>
                             ZLayer.succeed(other) >>> service(
                               configure

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageBackend.scala
@@ -53,7 +53,7 @@ object StorageBackend:
         config       <- ZIO.service[BackendConfig]
         selectedLayer = config match
                           case nativeLocal: BackendConfig.NativeLocal =>
-                            NativeLocal.live(nativeLocal.snapshotPath, descriptor)
+                            NativeLocal.live(nativeLocal.snapshotPath, descriptor, nativeLocal.serde)
                           case other                                  =>
                             ZLayer.succeed(other) >>> service(
                               configure

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageLock.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageLock.scala
@@ -1,0 +1,195 @@
+package io.github.riccardomerolla.zio.eclipsestore.service
+
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream }
+import java.lang.reflect.Modifier
+import java.util.concurrent.ConcurrentHashMap
+
+import zio.*
+import zio.stm.*
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** ZIO-native locking surface for rooted storage access. */
+trait StorageLock[Root]:
+  def readLock[A](effect: Root => IO[EclipseStoreError, A]): IO[EclipseStoreError, A]
+  def writeLock[A](effect: Root => IO[EclipseStoreError, A]): IO[EclipseStoreError, A]
+  def optimisticUpdate[A](
+    prepare: Root => IO[EclipseStoreError, A]
+  )(
+    commit: (Root, A) => IO[EclipseStoreError, A],
+    maxRetries: Int = 8,
+  ): IO[EclipseStoreError, A]
+
+final case class StorageLockLive[Root](
+  store: ObjectStore[Root],
+  state: TRef[StorageLockLive.State],
+) extends StorageLock[Root]:
+  override def readLock[A](effect: Root => IO[EclipseStoreError, A]): IO[EclipseStoreError, A] =
+    ZIO.uninterruptibleMask { restore =>
+      acquireRead.commit *> restore(store.load.flatMap(effect)).ensuring(releaseRead.commit)
+    }
+
+  override def writeLock[A](effect: Root => IO[EclipseStoreError, A]): IO[EclipseStoreError, A] =
+    ZIO.uninterruptibleMask { restore =>
+      acquireWrite.commit *>
+        restore {
+          for
+            root     <- store.load
+            snapshot <- RootSnapshot.capture(root)
+            exit     <- effect(root).exit
+            result   <- exit match
+                          case Exit.Success(value) =>
+                            store.checkpoint *> completeWrite(committed = true).commit.as(value)
+                          case Exit.Failure(cause) =>
+                            RootSnapshot.restore(root, snapshot) *>
+                              store.checkpoint.ignore *>
+                              completeWrite(committed = false).commit *>
+                              ZIO.failCause(cause)
+          yield result
+        }.ensuring(completeWrite(committed = false).commit)
+    }
+
+  override def optimisticUpdate[A](
+    prepare: Root => IO[EclipseStoreError, A]
+  )(
+    commit: (Root, A) => IO[EclipseStoreError, A],
+    maxRetries: Int = 8,
+  ): IO[EclipseStoreError, A] =
+    def loop(remaining: Int): IO[EclipseStoreError, A] =
+      for
+        prepared       <- readLock(root => prepare(root).zip(version))
+        (candidate, v0) = prepared
+        result         <- attemptOptimistic(candidate, v0, commit).either.flatMap {
+                            case Right(value)                                              => ZIO.succeed(value)
+                            case Left(_: EclipseStoreError.ConflictError) if remaining > 0 => loop(remaining - 1)
+                            case Left(error)                                               => ZIO.fail(error)
+                          }
+      yield result
+
+    loop(maxRetries)
+
+  private def version: UIO[Long] =
+    state.get.map(_.version).commit
+
+  private def attemptOptimistic[A](
+    prepared: A,
+    observedVersion: Long,
+    commit: (Root, A) => IO[EclipseStoreError, A],
+  ): IO[EclipseStoreError, A] =
+    ZIO.uninterruptibleMask { restore =>
+      acquireWrite.commit *>
+        restore {
+          for
+            currentVersion <- version
+            _              <-
+              if currentVersion == observedVersion then ZIO.unit
+              else
+                completeWrite(committed = false).commit *>
+                  ZIO.fail(
+                    EclipseStoreError.ConflictError(
+                      s"Optimistic update conflict: expected version $observedVersion but observed $currentVersion",
+                      None,
+                    )
+                  )
+            root           <- store.load
+            snapshot       <- RootSnapshot.capture(root)
+            exit           <- commit(root, prepared).exit
+            result         <- exit match
+                                case Exit.Success(value) =>
+                                  store.checkpoint *> completeWrite(committed = true).commit.as(value)
+                                case Exit.Failure(cause) =>
+                                  RootSnapshot.restore(root, snapshot) *>
+                                    store.checkpoint.ignore *>
+                                    completeWrite(committed = false).commit *>
+                                    ZIO.failCause(cause)
+          yield result
+        }.ensuring(completeWrite(committed = false).commit)
+    }
+
+  private val acquireRead: USTM[Unit] =
+    state.get.flatMap { current =>
+      STM.check(!current.writer) *> state.update(s => s.copy(readers = s.readers + 1))
+    }
+
+  private val releaseRead: USTM[Unit] =
+    state.update(s => s.copy(readers = math.max(0, s.readers - 1)))
+
+  private val acquireWrite: USTM[Unit] =
+    state.get.flatMap { current =>
+      STM.check(!current.writer && current.readers == 0) *> state.update(_.copy(writer = true))
+    }
+
+  private def completeWrite(committed: Boolean): USTM[Unit] =
+    state.update(s => s.copy(writer = false, version = if committed then s.version + 1 else s.version))
+
+object StorageLockLive:
+  final case class State(readers: Int, writer: Boolean, version: Long)
+
+object StorageLock:
+  def live[Root: Tag]: ZLayer[ObjectStore[Root], Nothing, StorageLock[Root]] =
+    ZLayer.fromZIO {
+      for
+        store <- ZIO.service[ObjectStore[Root]]
+        state <- TRef.make(StorageLockLive.State(readers = 0, writer = false, version = 0L)).commit
+      yield StorageLockLive(store, state)
+    }
+
+  def readLock[Root: Tag, A](effect: Root => IO[EclipseStoreError, A]): ZIO[StorageLock[Root], EclipseStoreError, A] =
+    ZIO.serviceWithZIO[StorageLock[Root]](_.readLock(effect))
+
+  def writeLock[Root: Tag, A](effect: Root => IO[EclipseStoreError, A]): ZIO[StorageLock[Root], EclipseStoreError, A] =
+    ZIO.serviceWithZIO[StorageLock[Root]](_.writeLock(effect))
+
+  def optimisticUpdate[Root: Tag, A](
+    prepare: Root => IO[EclipseStoreError, A]
+  )(
+    commit: (Root, A) => IO[EclipseStoreError, A],
+    maxRetries: Int = 8,
+  ): ZIO[StorageLock[Root], EclipseStoreError, A] =
+    ZIO.serviceWithZIO[StorageLock[Root]](_.optimisticUpdate(prepare)(commit, maxRetries))
+
+private object RootSnapshot:
+  def capture[A](root: A): IO[EclipseStoreError, A] =
+    ZIO
+      .attempt {
+        val bytes = ByteArrayOutputStream()
+        val out   = ObjectOutputStream(bytes)
+        try out.writeObject(root)
+        finally out.close()
+
+        val in = ObjectInputStream(ByteArrayInputStream(bytes.toByteArray))
+        try in.readObject().asInstanceOf[A]
+        finally in.close()
+      }
+      .mapError(cause => EclipseStoreError.ResourceError("Failed to capture root snapshot for rollback", Some(cause)))
+
+  def restore[A](target: A, snapshot: A): IO[EclipseStoreError, Unit] =
+    ZIO
+      .attempt {
+        (target, snapshot) match
+          case (targetMap: ConcurrentHashMap[?, ?], snapshotMap: ConcurrentHashMap[?, ?]) =>
+            val typedTarget   = targetMap.asInstanceOf[ConcurrentHashMap[Any, Any]]
+            val typedSnapshot = snapshotMap.asInstanceOf[ConcurrentHashMap[Any, Any]]
+            typedTarget.clear()
+            typedTarget.putAll(typedSnapshot)
+          case _                                                                          =>
+            copyFields(target.asInstanceOf[AnyRef], snapshot.asInstanceOf[AnyRef])
+      }
+      .mapError(cause =>
+        EclipseStoreError.ResourceError("Failed to restore root snapshot after aborted write", Some(cause))
+      )
+
+  private def copyFields(target: AnyRef, snapshot: AnyRef): Unit =
+    def hierarchy(current: Class[?]): List[Class[?]] =
+      Option(current.getSuperclass) match
+        case Some(parent) => current :: hierarchy(parent)
+        case None         => List(current)
+
+    val fields = hierarchy(target.getClass)
+      .flatMap(_.getDeclaredFields.toList)
+      .filterNot(field => Modifier.isStatic(field.getModifiers))
+
+    fields.foreach { field =>
+      field.setAccessible(true)
+      field.set(target, field.get(snapshot))
+    }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageOps.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/service/StorageOps.scala
@@ -1,0 +1,106 @@
+package io.github.riccardomerolla.zio.eclipsestore.service
+
+import java.nio.file.Path
+
+import zio.*
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+/** Typed operational interface for lifecycle, backup, restore, and housekeeping flows. */
+trait StorageOps[Root]:
+  def descriptor: RootDescriptor[Root]
+  def load: IO[EclipseStoreError, Root]
+  def status: UIO[LifecycleStatus]
+  def checkpoint: IO[EclipseStoreError, LifecycleStatus]
+  def backup(target: Path, includeConfig: Boolean = true): IO[EclipseStoreError, LifecycleStatus]
+  def exportTo(target: Path): IO[EclipseStoreError, LifecycleStatus]
+  def importFrom(source: Path): IO[EclipseStoreError, LifecycleStatus]
+  def restoreFrom(source: Path): IO[EclipseStoreError, LifecycleStatus]
+  def restart: IO[EclipseStoreError, LifecycleStatus]
+  def shutdown: IO[EclipseStoreError, LifecycleStatus]
+  def housekeep: IO[EclipseStoreError, LifecycleStatus]
+  def scheduleCheckpoints(schedule: Schedule[Any, Any, Any]): URIO[Scope, Fiber.Runtime[Nothing, Unit]]
+
+object StorageOps:
+  def live[Root: Tag](descriptor0: RootDescriptor[Root]): ZLayer[EclipseStoreService, Nothing, StorageOps[Root]] =
+    ZLayer.fromZIO {
+      ZIO.service[EclipseStoreService].map(StorageOpsLive(descriptor0, _))
+    }
+
+  def load[Root: Tag]: ZIO[StorageOps[Root], EclipseStoreError, Root] =
+    ZIO.serviceWithZIO[StorageOps[Root]](_.load)
+
+  val status: ZIO[StorageOps[?], Nothing, LifecycleStatus] =
+    ZIO.serviceWithZIO[StorageOps[?]](_.status)
+
+  def checkpoint[Root: Tag]: ZIO[StorageOps[Root], EclipseStoreError, LifecycleStatus] =
+    ZIO.serviceWithZIO[StorageOps[Root]](_.checkpoint)
+
+  def backup[Root: Tag](target: Path, includeConfig: Boolean = true)
+    : ZIO[StorageOps[Root], EclipseStoreError, LifecycleStatus] =
+    ZIO.serviceWithZIO[StorageOps[Root]](_.backup(target, includeConfig))
+
+  def exportTo[Root: Tag](target: Path): ZIO[StorageOps[Root], EclipseStoreError, LifecycleStatus] =
+    ZIO.serviceWithZIO[StorageOps[Root]](_.exportTo(target))
+
+  def importFrom[Root: Tag](source: Path): ZIO[StorageOps[Root], EclipseStoreError, LifecycleStatus] =
+    ZIO.serviceWithZIO[StorageOps[Root]](_.importFrom(source))
+
+  def restoreFrom[Root: Tag](source: Path): ZIO[StorageOps[Root], EclipseStoreError, LifecycleStatus] =
+    ZIO.serviceWithZIO[StorageOps[Root]](_.restoreFrom(source))
+
+  def restart[Root: Tag]: ZIO[StorageOps[Root], EclipseStoreError, LifecycleStatus] =
+    ZIO.serviceWithZIO[StorageOps[Root]](_.restart)
+
+  def shutdown[Root: Tag]: ZIO[StorageOps[Root], EclipseStoreError, LifecycleStatus] =
+    ZIO.serviceWithZIO[StorageOps[Root]](_.shutdown)
+
+  def housekeep[Root: Tag]: ZIO[StorageOps[Root], EclipseStoreError, LifecycleStatus] =
+    ZIO.serviceWithZIO[StorageOps[Root]](_.housekeep)
+
+  def scheduleCheckpoints[Root: Tag](
+    schedule: Schedule[Any, Any, Any]
+  ): ZIO[StorageOps[Root] & Scope, Nothing, Fiber.Runtime[Nothing, Unit]] =
+    ZIO.serviceWithZIO[StorageOps[Root]](_.scheduleCheckpoints(schedule))
+
+final case class StorageOpsLive[Root](
+  descriptor: RootDescriptor[Root],
+  underlying: EclipseStoreService,
+) extends StorageOps[Root]:
+  override def load: IO[EclipseStoreError, Root] =
+    underlying.root(descriptor)
+
+  override val status: UIO[LifecycleStatus] =
+    underlying.status
+
+  override def checkpoint: IO[EclipseStoreError, LifecycleStatus] =
+    underlying.maintenance(LifecycleCommand.Checkpoint)
+
+  override def backup(target: Path, includeConfig: Boolean = true): IO[EclipseStoreError, LifecycleStatus] =
+    underlying.maintenance(LifecycleCommand.Backup(target, includeConfig))
+
+  override def exportTo(target: Path): IO[EclipseStoreError, LifecycleStatus] =
+    underlying.exportData(target) *> status
+
+  override def importFrom(source: Path): IO[EclipseStoreError, LifecycleStatus] =
+    underlying.importData(source) *> underlying.reloadRoots *> status
+
+  override def restoreFrom(source: Path): IO[EclipseStoreError, LifecycleStatus] =
+    importFrom(source)
+
+  override def restart: IO[EclipseStoreError, LifecycleStatus] =
+    underlying.maintenance(LifecycleCommand.Restart)
+
+  override def shutdown: IO[EclipseStoreError, LifecycleStatus] =
+    underlying.maintenance(LifecycleCommand.Shutdown)
+
+  override def housekeep: IO[EclipseStoreError, LifecycleStatus] =
+    checkpoint *> underlying.reloadRoots *> status
+
+  override def scheduleCheckpoints(schedule: Schedule[Any, Any, Any]): URIO[Scope, Fiber.Runtime[Nothing, Unit]] =
+    checkpoint
+      .ignore
+      .repeat(schedule)
+      .unit
+      .forkScoped

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/BddScenario.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/BddScenario.scala
@@ -1,0 +1,47 @@
+package io.github.riccardomerolla.zio.eclipsestore.testkit
+
+import zio.*
+import zio.test.*
+
+final case class BddScenario[-R, +E, A](
+  title: String,
+  givenLabel: String,
+  givenStep: ZIO[R, E, Unit],
+  whenLabel: String,
+  whenStep: ZIO[R, E, A],
+  thenLabel: String,
+  assertion: A => TestResult,
+):
+  def spec: Spec[R, E] =
+    zio.test.test(s"$title | Given $givenLabel | When $whenLabel | Then $thenLabel") {
+      for
+        _      <- givenStep
+        result <- whenStep
+      yield assertion(result)
+    }
+
+object BddScenario:
+  def scenario(title: String): BddGivenBuilder =
+    BddGivenBuilder(title)
+
+  final case class BddGivenBuilder(title: String):
+    def `given`[R, E](label: String)(step: ZIO[R, E, Unit]): BddWhenBuilder[R, E] =
+      BddWhenBuilder(title, label, step)
+
+  final case class BddWhenBuilder[R, E](
+    title: String,
+    givenLabel: String,
+    givenStep: ZIO[R, E, Unit],
+  ):
+    def when[A](label: String)(step: ZIO[R, E, A]): BddThenBuilder[R, E, A] =
+      BddThenBuilder(title, givenLabel, givenStep, label, step)
+
+  final case class BddThenBuilder[R, E, A](
+    title: String,
+    givenLabel: String,
+    givenStep: ZIO[R, E, Unit],
+    whenLabel: String,
+    whenStep: ZIO[R, E, A],
+  ):
+    def thenAssert(label: String)(assertion: A => TestResult): BddScenario[R, E, A] =
+      BddScenario(title, givenLabel, givenStep, whenLabel, whenStep, label, assertion)

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/FaultInjector.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/FaultInjector.scala
@@ -35,12 +35,12 @@ object FaultInjector:
   val triggeredOperations: ZIO[FaultInjector, Nothing, Chunk[String]] =
     ZIO.serviceWithZIO[FaultInjector](_.triggeredOperations)
 
-private final case class FaultPlan(
+final private case class FaultPlan(
   error: EclipseStoreError,
   cleanup: UIO[Unit],
 )
 
-private final case class InMemoryFaultInjector(
+final private case class InMemoryFaultInjector(
   plans: Ref[Map[String, Chunk[FaultPlan]]],
   triggered: Ref[Chunk[String]],
 ) extends FaultInjector:
@@ -77,4 +77,3 @@ private final case class InMemoryFaultInjector(
 
   override def triggeredOperations: UIO[Chunk[String]] =
     triggered.get
-

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/FaultInjector.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/FaultInjector.scala
@@ -1,0 +1,80 @@
+package io.github.riccardomerolla.zio.eclipsestore.testkit
+
+import zio.*
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+trait FaultInjector:
+  def inject[A](operation: String)(effect: IO[EclipseStoreError, A]): IO[EclipseStoreError, A]
+  def failNext(
+    operation: String,
+    error: EclipseStoreError,
+    cleanup: UIO[Unit] = ZIO.unit,
+  ): UIO[Unit]
+  def triggeredOperations: UIO[Chunk[String]]
+
+object FaultInjector:
+  def inMemory: ULayer[FaultInjector] =
+    ZLayer.fromZIO {
+      for
+        plans     <- Ref.make(Map.empty[String, Chunk[FaultPlan]])
+        triggered <- Ref.make(Chunk.empty[String])
+      yield InMemoryFaultInjector(plans, triggered)
+    }
+
+  def inject[A](operation: String)(effect: IO[EclipseStoreError, A]): ZIO[FaultInjector, EclipseStoreError, A] =
+    ZIO.serviceWithZIO[FaultInjector](_.inject(operation)(effect))
+
+  def failNext(
+    operation: String,
+    error: EclipseStoreError,
+    cleanup: UIO[Unit] = ZIO.unit,
+  ): ZIO[FaultInjector, Nothing, Unit] =
+    ZIO.serviceWithZIO[FaultInjector](_.failNext(operation, error, cleanup))
+
+  val triggeredOperations: ZIO[FaultInjector, Nothing, Chunk[String]] =
+    ZIO.serviceWithZIO[FaultInjector](_.triggeredOperations)
+
+private final case class FaultPlan(
+  error: EclipseStoreError,
+  cleanup: UIO[Unit],
+)
+
+private final case class InMemoryFaultInjector(
+  plans: Ref[Map[String, Chunk[FaultPlan]]],
+  triggered: Ref[Chunk[String]],
+) extends FaultInjector:
+  override def inject[A](operation: String)(effect: IO[EclipseStoreError, A]): IO[EclipseStoreError, A] =
+    for
+      maybePlan <- plans.modify { current =>
+                     current.get(operation) match
+                       case Some(entries) if entries.nonEmpty =>
+                         val remaining = entries.tail
+                         val updated   =
+                           if remaining.isEmpty then current - operation
+                           else current.updated(operation, remaining)
+                         (Some(entries.head), updated)
+                       case _                                 =>
+                         (None, current)
+                   }
+      result    <- maybePlan match
+                     case Some(plan) =>
+                       triggered.update(_ :+ operation) *>
+                         plan.cleanup *>
+                         ZIO.fail(plan.error)
+                     case None       =>
+                       effect
+    yield result
+
+  override def failNext(
+    operation: String,
+    error: EclipseStoreError,
+    cleanup: UIO[Unit] = ZIO.unit,
+  ): UIO[Unit] =
+    plans.update(current =>
+      current.updated(operation, current.getOrElse(operation, Chunk.empty) :+ FaultPlan(error, cleanup))
+    )
+
+  override def triggeredOperations: UIO[Chunk[String]] =
+    triggered.get
+

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/InMemoryObjectStore.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/InMemoryObjectStore.scala
@@ -1,0 +1,11 @@
+package io.github.riccardomerolla.zio.eclipsestore.testkit
+
+import zio.*
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, ObjectStore }
+
+object InMemoryObjectStore:
+  def layer[Root: Tag](descriptor: RootDescriptor[Root]): ULayer[ObjectStore[Root]] =
+    EclipseStoreService.inMemory >>> ObjectStore.live(descriptor)
+

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/InMemoryObjectStore.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/InMemoryObjectStore.scala
@@ -8,4 +8,3 @@ import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService,
 object InMemoryObjectStore:
   def layer[Root: Tag](descriptor: RootDescriptor[Root]): ULayer[ObjectStore[Root]] =
     EclipseStoreService.inMemory >>> ObjectStore.live(descriptor)
-

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala
@@ -9,7 +9,7 @@ import zio.schema.Schema
 
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
-import io.github.riccardomerolla.zio.eclipsestore.service.{ NativeLocal, ObjectStore, StorageOps }
+import io.github.riccardomerolla.zio.eclipsestore.service.{ NativeLocal, NativeLocalSTM, ObjectStore, StorageOps }
 
 object NativeLocalObjectStore:
   def layer[Root: Tag: Schema](
@@ -30,6 +30,22 @@ object NativeLocalObjectStore:
       yield ZEnvironment[ObjectStore[Root], StorageOps[Root]](
         built.get[ObjectStore[Root]],
         built.get[StorageOps[Root]],
+      )
+    }
+
+  def tempLayerWithSTM[Root: Tag: Schema](
+    descriptor: RootDescriptor[Root],
+    prefix: String = "native-local-testkit-stm",
+  ): ZLayer[Scope, EclipseStoreError, ObjectStore[Root] & StorageOps[Root] & NativeLocalSTM[Root]] =
+    ZLayer.scopedEnvironment {
+      for
+        snapshotDir <- ZIO.acquireRelease(createTempDirectory(prefix))(deleteDirectory)
+        snapshotPath = snapshotDir.resolve(s"${descriptor.id}.snapshot.json")
+        built       <- NativeLocal.liveWithSTM(snapshotPath, descriptor).build
+      yield ZEnvironment[ObjectStore[Root], StorageOps[Root], NativeLocalSTM[Root]](
+        built.get[ObjectStore[Root]],
+        built.get[StorageOps[Root]],
+        built.get[NativeLocalSTM[Root]],
       )
     }
 

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/NativeLocalObjectStore.scala
@@ -1,0 +1,49 @@
+package io.github.riccardomerolla.zio.eclipsestore.testkit
+
+import java.nio.file.{ Files, Path }
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.schema.Schema
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.{ NativeLocal, ObjectStore, StorageOps }
+
+object NativeLocalObjectStore:
+  def layer[Root: Tag: Schema](
+    snapshotPath: Path,
+    descriptor: RootDescriptor[Root],
+  ): ZLayer[Any, EclipseStoreError, ObjectStore[Root] & StorageOps[Root]] =
+    NativeLocal.live(snapshotPath, descriptor)
+
+  def tempLayer[Root: Tag: Schema](
+    descriptor: RootDescriptor[Root],
+    prefix: String = "native-local-testkit",
+  ): ZLayer[Scope, EclipseStoreError, ObjectStore[Root] & StorageOps[Root]] =
+    ZLayer.scopedEnvironment {
+      for
+        snapshotDir <- ZIO.acquireRelease(createTempDirectory(prefix))(deleteDirectory)
+        snapshotPath = snapshotDir.resolve(s"${descriptor.id}.snapshot.json")
+        built       <- layer(snapshotPath, descriptor).build
+      yield ZEnvironment[ObjectStore[Root], StorageOps[Root]](
+        built.get[ObjectStore[Root]],
+        built.get[StorageOps[Root]],
+      )
+    }
+
+  private def createTempDirectory(prefix: String): IO[EclipseStoreError, Path] =
+    ZIO
+      .attemptBlocking(Files.createTempDirectory(prefix))
+      .mapError(cause =>
+        EclipseStoreError.ResourceError(s"Failed to create NativeLocal testkit directory for $prefix", Some(cause))
+      )
+
+  private def deleteDirectory(path: Path): UIO[Unit] =
+    ZIO
+      .attemptBlocking {
+        if Files.exists(path) then
+          Files.walk(path).iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists)
+      }
+      .ignore

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/PersistenceGenerators.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/PersistenceGenerators.scala
@@ -1,0 +1,29 @@
+package io.github.riccardomerolla.zio.eclipsestore.testkit
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.schema.{ DeriveSchema, Schema }
+import zio.test.Gen
+
+object PersistenceGenerators:
+  final case class MessageEvent(id: String, body: String, version: Int)
+  given Schema[MessageEvent] = DeriveSchema.gen[MessageEvent]
+
+  val messageEvent: Gen[Any, MessageEvent] =
+    for
+      id      <- Gen.alphaNumericStringBounded(1, 12)
+      body    <- Gen.alphaNumericStringBounded(1, 32)
+      version <- Gen.int(1, 100)
+    yield MessageEvent(id, body, version)
+
+  val stringMap: Gen[Any, ConcurrentHashMap[String, String]] =
+    Gen.listOfBounded(1, 8)(
+      Gen.alphaNumericStringBounded(1, 12).zip(Gen.alphaNumericStringBounded(1, 12))
+    ).map { entries =>
+      val map = new ConcurrentHashMap[String, String]()
+      entries.foreach { case (k, v) => map.put(k, v) }
+      map
+    }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/PersistenceSpec.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/PersistenceSpec.scala
@@ -1,0 +1,22 @@
+package io.github.riccardomerolla.zio.eclipsestore.testkit
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+object PersistenceSpec:
+  def parity[A](
+    title: String
+  )(
+    live: => IO[EclipseStoreError, A],
+    inMemory: => IO[EclipseStoreError, A],
+  )(
+    assertion: (A, A) => TestResult
+  ): Spec[TestEnvironment & Scope, Any] =
+    zio.test.test(title) {
+      for
+        liveResult     <- live
+        inMemoryResult <- inMemory
+      yield assertion(liveResult, inMemoryResult)
+    }

--- a/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/PersistenceSpec.scala
+++ b/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/testkit/PersistenceSpec.scala
@@ -6,6 +6,17 @@ import zio.test.*
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 
 object PersistenceSpec:
+  def compare[A, B](
+    live: => IO[EclipseStoreError, A],
+    baseline: => IO[EclipseStoreError, B],
+  )(
+    assertion: (A, B) => TestResult
+  ): IO[EclipseStoreError, TestResult] =
+    for
+      liveResult     <- live
+      baselineResult <- baseline
+    yield assertion(liveResult, baselineResult)
+
   def parity[A](
     title: String
   )(
@@ -15,8 +26,17 @@ object PersistenceSpec:
     assertion: (A, A) => TestResult
   ): Spec[TestEnvironment & Scope, Any] =
     zio.test.test(title) {
-      for
-        liveResult     <- live
-        inMemoryResult <- inMemory
-      yield assertion(liveResult, inMemoryResult)
+      compare(live, inMemory)(assertion)
+    }
+
+  def modelParity[A, B](
+    title: String
+  )(
+    live: => IO[EclipseStoreError, A],
+    model: => UIO[B],
+  )(
+    assertion: (A, B) => TestResult
+  ): Spec[TestEnvironment & Scope, Any] =
+    zio.test.test(title) {
+      compare(live, model)(assertion)
     }

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/ApiContractSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/ApiContractSpec.scala
@@ -8,12 +8,14 @@ import zio.test.*
 
 import io.github.riccardomerolla.zio.eclipsestore.error.{ EclipseStoreError, PersistenceError }
 import io.github.riccardomerolla.zio.eclipsestore.schema.TypedStore
-import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, LocalRepo, NativeLocalSTM }
 
 object ApiContractSpec extends ZIOSpecDefault:
 
   private val publicApiTypes = List(
     classOf[EclipseStoreService],
+    classOf[LocalRepo[?, ?]],
+    classOf[NativeLocalSTM[?]],
     classOf[TypedStore],
   )
 

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/ApiContractSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/ApiContractSpec.scala
@@ -1,0 +1,74 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import java.lang.reflect.{ Method, Modifier, ParameterizedType, Type, TypeVariable }
+
+import zio.*
+import zio.stream.ZStream
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.error.{ EclipseStoreError, PersistenceError }
+import io.github.riccardomerolla.zio.eclipsestore.schema.TypedStore
+import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+
+object ApiContractSpec extends ZIOSpecDefault:
+
+  private val publicApiTypes = List(
+    classOf[EclipseStoreService],
+    classOf[TypedStore],
+  )
+
+  private val zioReturnType     = classOf[ZIO[Any, Any, Any]]
+  private val zstreamReturnType = classOf[ZStream[Any, Any, Any]]
+
+  private def publicDeclaredMethods(cls: Class[?]): List[Method] =
+    cls.getDeclaredMethods.toList.filter { m =>
+      Modifier.isPublic(m.getModifiers) &&
+      Modifier.isAbstract(m.getModifiers) &&
+      !Modifier.isStatic(m.getModifiers) &&
+      !m.isSynthetic
+    }
+
+  private def exposedBoundaryTypes(method: Method): List[Class[?]] =
+    def topLevelClass(tpe: Type): List[Class[?]] =
+      tpe match
+        case cls: Class[?]                    => List(cls)
+        case parameterized: ParameterizedType =>
+          parameterized.getRawType match
+            case cls: Class[?] => List(cls)
+            case _             => Nil
+        case _: TypeVariable[?]               => Nil
+        case _                                => Nil
+
+    method.getGenericParameterTypes.toList.flatMap(topLevelClass) ++ topLevelClass(method.getGenericReturnType)
+
+  private def formatMethod(method: Method): String =
+    s"${method.getDeclaringClass.getSimpleName}.${method.getName}"
+
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("Scala-native API contract")(
+      test("public service methods return effect or stream descriptions") {
+        val invalidMethods =
+          publicApiTypes.flatMap(publicDeclaredMethods).filterNot { method =>
+            val returnType = method.getReturnType
+            zioReturnType.isAssignableFrom(returnType) ||
+            zstreamReturnType.isAssignableFrom(returnType)
+          }
+
+        assertTrue(invalidMethods.isEmpty)
+      },
+      test("public service methods do not expose java.util collections or raw Object") {
+        val violations =
+          publicApiTypes.flatMap(publicDeclaredMethods).flatMap { method =>
+            val referencedTypes = exposedBoundaryTypes(method)
+            val badTypes        = referencedTypes.filter(t => t == classOf[Object] || t.getName.startsWith("java.util."))
+            badTypes.map(t => s"${formatMethod(method)} exposes ${t.getName}")
+          }
+
+        assertTrue(violations.isEmpty)
+      },
+      test("public storage error ADTs share the PersistenceError contract") {
+        assertTrue(
+          classOf[PersistenceError].isAssignableFrom(classOf[EclipseStoreError])
+        )
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/LazyLoadingSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/LazyLoadingSpec.scala
@@ -1,105 +1,100 @@
 package io.github.riccardomerolla.zio.eclipsestore
 
-import java.nio.file.Files
-import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
-import java.util.{ ArrayList, Iterator as JIterator, List as JList }
-
-import scala.jdk.CollectionConverters.*
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream }
+import java.util.concurrent.atomic.AtomicInteger
 
 import zio.*
 import zio.test.*
 
-import io.github.riccardomerolla.zio.eclipsestore.config.{ EclipseStoreConfig, StorageTarget }
-import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
-import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
-import org.eclipse.serializer.reference.Lazy
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 
 object LazyLoadingSpec extends ZIOSpecDefault:
 
-  final case class Turnover(amount: Double, timestamp: Instant)
+  final case class LazyRoot(
+    customers: Lazy[List[String]],
+    invoices: Lazy[List[Int]],
+    audits: Lazy[List[String]],
+  ) extends Serializable
 
-  final class BusinessYear(private var turnovers: Lazy[JList[Turnover]] = null):
-    private def ensureTurnovers(): JList[Turnover] =
-      val current = Lazy.get(turnovers)
-      if current != null then current // scalafix:ok DisableSyntax.null
-      else
-        val fresh = new ArrayList[Turnover]()
-        turnovers = Lazy.Reference(fresh)
-        fresh
+  final case class LazyEnvelope(value: Lazy[Int]) extends Serializable
 
-    def add(turnover: Turnover): Unit =
-      ensureTurnovers().add(turnover)
+  private def roundTrip[A](value: A): Task[A] =
+    ZIO.attempt {
+      val bytes = ByteArrayOutputStream()
+      val out   = ObjectOutputStream(bytes)
+      out.writeObject(value)
+      out.flush()
+      out.close()
 
-    def stream: Iterator[Turnover] =
-      val data = Lazy.get(turnovers)
-      if data == null then Iterator.empty // scalafix:ok DisableSyntax.null
-      else
-        val it: JIterator[Turnover] = data.iterator()
-        it.asScala
+      val in = ObjectInputStream(ByteArrayInputStream(bytes.toByteArray))
+      try in.readObject().asInstanceOf[A]
+      finally in.close()
+    }
 
-  override def spec: Spec[Environment & (TestEnvironment & Scope), Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("Lazy loading primitives")(
-      test("Lazy.Reference exposes value and updates touched timestamp") {
-        val ref        = LazyHelpers.reference("lazy-value")
-        val touched0   = ref.lastTouched()
-        val value      = ref.get()
-        val touchedNow = ref.lastTouched()
-        assertTrue(value == "lazy-value", touchedNow >= touched0, LazyHelpers.isLoaded(ref))
+      test("only explicitly loaded lazy fields are materialized") {
+        for
+          loaded <- Ref.make(List.empty[String])
+          root    = LazyRoot(
+                      customers = Lazy.fromZIO(loaded.update(_ :+ "customers").as(List("alice", "bob"))),
+                      invoices = Lazy.fromZIO(loaded.update(_ :+ "invoices").as(List(1, 2, 3))),
+                      audits = Lazy.fromZIO(loaded.update(_ :+ "audits").as(List("created"))),
+                    )
+          _      <- root.customers.load
+          _      <- root.invoices.load
+          seen   <- loaded.get
+        yield assertTrue(seen == List("customers", "invoices"))
       },
-      test("LazyReferenceManager registers and iterates lazy references") {
-        val ref1      = LazyHelpers.reference("a")
-        val ref2      = LazyHelpers.reference("b")
-        val manager   = LazyHelpers.newManager()
-        manager.register(ref1)
-        manager.register(ref2)
-        val buffer    = scala.collection.mutable.ListBuffer.empty[Lazy[?]]
-        manager.iterate(
-          new java.util.function.Consumer[Lazy[?]]:
-            override def accept(t: Lazy[?]): Unit = buffer += t
+      test("concurrent loads coalesce to a single underlying fetch") {
+        for
+          starts  <- Ref.make(0)
+          gate    <- Promise.make[Nothing, Unit]
+          lazyRef  = Lazy.fromZIO(
+                       starts.updateAndGet(_ + 1) *> gate.await *> ZIO.succeed("loaded-once")
+                     )
+          fibers  <- ZIO.foreach(1 to 20)(_ => lazyRef.load.fork)
+          _       <- gate.succeed(())
+          results <- ZIO.foreach(fibers)(_.join)
+          count   <- starts.get
+        yield assertTrue(results.forall(_ == "loaded-once"), count == 1)
+      },
+      test("loading after the backing store has closed fails with a typed store-not-open error") {
+        val program =
+          ZIO.scoped {
+            for
+              open   <- Ref.make(true)
+              _      <- ZIO.addFinalizer(open.set(false))
+              lazyRef = Lazy.fromZIO(
+                          open.get.flatMap {
+                            case true  => ZIO.succeed(42)
+                            case false => ZIO.fail(EclipseStoreError.StoreNotOpen("Scoped loader is closed", None))
+                          }
+                        )
+            yield lazyRef
+          }
+
+        for
+          lazyRef <- program
+          result  <- lazyRef.load.either
+        yield assertTrue(
+          result == Left(EclipseStoreError.StoreNotOpen("Scoped loader is closed", None))
         )
-        val collected = buffer.size
-        assertTrue(collected == 2)
       },
-      test("Lazy reference clear resets loaded state and touched timestamp") {
-        val ref      = LazyHelpers.reference("to-clear")
-        val touched  = ref.lastTouched()
-        val value    = ref.get()
-        val afterGet = ref.lastTouched()
-        assertTrue(
-          value == "to-clear",
-          afterGet >= touched,
-          LazyHelpers.isLoaded(ref),
-        )
+      test("serialized lazy fields return unloaded and load on demand after deserialization") {
+        for
+          value       <- ZIO.succeed(LazyEnvelope(Lazy.succeed(99)))
+          serialized  <- roundTrip(value)
+          beforeLoad  <- serialized.value.isLoaded
+          loadedValue <- serialized.value.load
+        yield assertTrue(!beforeLoad, loadedValue == 99)
       },
-      test("lazy list survives reload and loads on demand") {
-        ZIO.scoped {
-          for
-            dir           <- ZIO.attemptBlocking(Files.createTempDirectory("lazy-root"))
-            _             <- ZIO.addFinalizer(
-                               ZIO
-                                 .attemptBlocking(Files.walk(dir).sorted(java.util.Comparator.reverseOrder()).forEach(Files.delete))
-                                 .ignore
-                             )
-            layer          = ZLayer.succeed(
-                               EclipseStoreConfig(storageTarget = StorageTarget.FileSystem(dir))
-                             ) >>> EclipseStoreService.live
-            rootDescriptor = RootDescriptor(
-                               id = "lazy-root",
-                               initializer = () => new ConcurrentHashMap[Int, BusinessYear](),
-                             )
-            _             <- (for
-                               root <- EclipseStoreService.root(rootDescriptor)
-                               year  = root.computeIfAbsent(2023, _ => new BusinessYear())
-                               _     = year.add(Turnover(100.0, Instant.EPOCH))
-                               _    <- EclipseStoreService.persist(root)
-                             yield ()).provideLayer(layer)
-            reloaded      <- (for
-                               root <- EclipseStoreService.root(rootDescriptor)
-                               year  = root.get(2023)
-                               data  = Option(year).toList.flatMap(_.stream.toList)
-                             yield data).provideLayer(layer)
-          yield assertTrue(reloaded.nonEmpty, reloaded.head.amount == 100.0)
-        }
+      test("memoized successful loads stay observationally equivalent to a single load") {
+        for
+          counter <- ZIO.succeed(AtomicInteger(0))
+          lazyRef  = Lazy.fromZIO(ZIO.succeed(counter.incrementAndGet()))
+          first   <- lazyRef.load
+          second  <- lazyRef.load
+        yield assertTrue(first == 1, second == 1, counter.get() == 1)
       },
     )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/LocalRepoSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/LocalRepoSpec.scala
@@ -1,0 +1,80 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import java.nio.file.Files
+
+import zio.*
+import zio.schema.{ DeriveSchema, Schema }
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.service.{ LocalRepo, NativeLocal, StorageOps }
+
+object LocalRepoSpec extends ZIOSpecDefault:
+
+  final case class TodoEntry(title: String, completed: Boolean)
+  final case class TodoRegistry(entries: Map[String, TodoEntry])
+
+  given Schema[TodoEntry]    = DeriveSchema.gen[TodoEntry]
+  given Schema[TodoRegistry] = DeriveSchema.gen[TodoRegistry]
+  given Tag[TodoRegistry]    = Tag.derived
+
+  private val descriptor =
+    RootDescriptor.fromSchema[TodoRegistry](
+      id = "todo-registry",
+      initializer = () => TodoRegistry(Map.empty),
+    )
+
+  private def layer(path: java.nio.file.Path) =
+    NativeLocal.live(path, descriptor) >>> LocalRepo.fromMap[TodoRegistry, String, TodoEntry](_.entries) {
+      (root, entries) =>
+        root.copy(entries = entries)
+    }
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("LocalRepo")(
+      test("upserts, loads, lists, and deletes entries in a NativeLocal root") {
+        ZIO.scoped {
+          for
+            path                  <- ZIO.attemptBlocking(Files.createTempFile("local-repo", ".json"))
+            _                     <- ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore
+            _                     <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore)
+            repo                   = layer(path)
+            result                <- (for
+                                       _    <- LocalRepo.upsert("todo-1", TodoEntry("write helper", completed = false))
+                                       _    <- LocalRepo.upsert("todo-2", TodoEntry("checkpoint root", completed = true))
+                                       one  <- LocalRepo.get[String, TodoEntry]("todo-1")
+                                       all  <- LocalRepo.entries[String, TodoEntry]
+                                       gone <- LocalRepo.delete[String, TodoEntry]("todo-1")
+                                       miss <- LocalRepo.get[String, TodoEntry]("todo-1")
+                                     yield (one, all, gone, miss)).provideLayer(repo)
+            (one, all, gone, miss) = result
+          yield assertTrue(
+            one.contains(TodoEntry("write helper", completed = false)),
+            all.keySet == Set("todo-1", "todo-2"),
+            gone.contains(TodoEntry("write helper", completed = false)),
+            miss.isEmpty,
+          )
+        }
+      },
+      test("persists repo updates across checkpoint and restart") {
+        ZIO.scoped {
+          for
+            path    <- ZIO.attemptBlocking(Files.createTempFile("local-repo-restart", ".json"))
+            _       <- ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore
+            _       <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore)
+            services = NativeLocal.live(path, descriptor)
+            repo     = services >>> LocalRepo.fromMap[TodoRegistry, String, TodoEntry](_.entries) { (root, entries) =>
+                         root.copy(entries = entries)
+                       }
+            out     <- (for
+                         _   <- LocalRepo.upsert("todo-1", TodoEntry("survive restart", completed = false))
+                         _   <- StorageOps.checkpoint[TodoRegistry]
+                         _   <- StorageOps.restart[TodoRegistry]
+                         out <- LocalRepo.entries[String, TodoEntry]
+                       yield out).provideLayer(repo ++ services)
+          yield assertTrue(
+            out == Map("todo-1" -> TodoEntry("survive restart", completed = false))
+          )
+        }
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/NativeLocalSTMSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/NativeLocalSTMSpec.scala
@@ -1,0 +1,105 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import java.nio.file.Files
+
+import zio.*
+import zio.schema.{ DeriveSchema, Schema }
+import zio.stm.STM
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.{ NativeLocal, NativeLocalSTM, ObjectStore, StorageOps }
+
+object NativeLocalSTMSpec extends ZIOSpecDefault:
+
+  final case class CounterRoot(total: Int, labels: Chunk[String])
+
+  given Schema[CounterRoot] = DeriveSchema.gen[CounterRoot]
+  given Tag[CounterRoot]    = Tag.derived
+
+  private val descriptor =
+    RootDescriptor.fromSchema[CounterRoot](
+      id = "native-local-stm-root",
+      initializer = () => CounterRoot(0, Chunk.empty),
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("NativeLocalSTM")(
+      test("commits STM updates into the shared NativeLocal root and survives restart") {
+        ZIO.scoped {
+          for
+            path <- ZIO.attemptBlocking(Files.createTempFile("native-local-stm", ".json"))
+            _    <- ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore
+            _    <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore)
+            layer = NativeLocal.liveWithSTM(path, descriptor)
+            out  <- (for
+                      _ <- NativeLocalSTM.atomically[CounterRoot, Unit](_.update(root =>
+                             root.copy(total = root.total + 1, labels = root.labels :+ "stm-1")
+                           ))
+                      _ <- NativeLocalSTM.atomically[CounterRoot, Unit](_.update(root =>
+                             root.copy(total = root.total + 2, labels = root.labels :+ "stm-2")
+                           ))
+                      _ <- StorageOps.checkpoint[CounterRoot]
+                      _ <- StorageOps.restart[CounterRoot]
+                      s <- NativeLocalSTM.snapshot[CounterRoot]
+                    yield s).provideLayer(layer)
+          yield assertTrue(
+            out.total == 3,
+            out.labels == Chunk("stm-1", "stm-2"),
+          )
+        }
+      },
+      test("failed STM transactions leave the NativeLocal root unchanged") {
+        ZIO.scoped {
+          for
+            path              <- ZIO.attemptBlocking(Files.createTempFile("native-local-stm-failure", ".json"))
+            _                 <- ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore
+            _                 <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore)
+            layer              = NativeLocal.liveWithSTM(path, descriptor)
+            out               <- (for
+                                   _      <- NativeLocalSTM.atomically[CounterRoot, Unit](_.update(root =>
+                                               root.copy(total = 1, labels = Chunk("ok"))
+                                             ))
+                                   failed <- NativeLocalSTM
+                                               .atomically[CounterRoot, Unit] { ref =>
+                                                 for
+                                                   _ <- ref.update(root => root.copy(total = 999, labels = root.labels :+ "boom"))
+                                                   _ <- STM.fail(
+                                                          EclipseStoreError.QueryError("synthetic STM failure", None)
+                                                        )
+                                                 yield ()
+                                               }
+                                               .either
+                                   s      <- NativeLocalSTM.snapshot[CounterRoot]
+                                 yield (failed, s)).provideLayer(layer)
+            (failed, snapshot) = out
+          yield assertTrue(
+            failed == Left(EclipseStoreError.QueryError("synthetic STM failure", None)),
+            snapshot == CounterRoot(1, Chunk("ok")),
+          )
+        }
+      },
+      test("ObjectStore and NativeLocalSTM observe the same shared root state") {
+        ZIO.scoped {
+          for
+            path                    <- ZIO.attemptBlocking(Files.createTempFile("native-local-stm-shared-root", ".json"))
+            _                       <- ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore
+            _                       <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore)
+            layer                    = NativeLocal.liveWithSTM(path, descriptor)
+            out                     <- (for
+                                         _ <- ObjectStore.replace[CounterRoot](CounterRoot(2, Chunk("object-store")))
+                                         a <- NativeLocalSTM.snapshot[CounterRoot]
+                                         _ <- NativeLocalSTM.atomically[CounterRoot, Unit](_.update(root =>
+                                                root.copy(total = root.total + 5, labels = root.labels :+ "stm")
+                                              ))
+                                         b <- ObjectStore.load[CounterRoot]
+                                       yield (a, b)).provideLayer(layer)
+            (afterReplace, afterStm) = out
+          yield assertTrue(
+            afterReplace == CounterRoot(2, Chunk("object-store")),
+            afterStm == CounterRoot(7, Chunk("object-store", "stm")),
+          )
+        }
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/ObjectStoreSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/ObjectStoreSpec.scala
@@ -1,28 +1,37 @@
 package io.github.riccardomerolla.zio.eclipsestore
 
 import java.nio.file.{ Files, Path }
-import java.util.Comparator
 import java.util.concurrent.ConcurrentHashMap
-import java.util.{ ArrayList, List as JList }
+import java.util.{ ArrayList, Comparator, List as JList }
 
 import scala.jdk.CollectionConverters.*
 
 import zio.*
+import zio.schema.{ DeriveSchema, Schema }
 import zio.test.*
 
 import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfig
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
-import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, ObjectStore, Transaction }
+import io.github.riccardomerolla.zio.eclipsestore.service.{
+  EclipseStoreService,
+  NativeLocal,
+  ObjectStore,
+  SnapshotCodec,
+  Transaction,
+}
 
 object ObjectStoreSpec extends ZIOSpecDefault:
 
-  final class EmployeeDirectory(val employees: JList[String]) extends Serializable
+  final class EmployeeDirectory(val employees: JList[String])             extends Serializable
   final class OrganizationRoot(val departments: JList[EmployeeDirectory]) extends Serializable
+  final case class TodoRoot(items: Chunk[String])
 
-  given Tag[EmployeeDirectory] = Tag.derived
-  given Tag[OrganizationRoot]  = Tag.derived
+  given Tag[EmployeeDirectory]              = Tag.derived
+  given Tag[OrganizationRoot]               = Tag.derived
   given Tag[ConcurrentHashMap[Int, String]] = Tag.derived
+  given Schema[TodoRoot]                    = DeriveSchema.gen[TodoRoot]
+  given Tag[TodoRoot]                       = Tag.derived
 
   private val organizationDescriptor =
     RootDescriptor(
@@ -40,6 +49,9 @@ object ObjectStoreSpec extends ZIOSpecDefault:
 
   private val counterDescriptor =
     RootDescriptor.concurrentMap[Int, String]("counter-root")
+
+  private val todoDescriptor =
+    RootDescriptor.fromSchema[TodoRoot]("todo-root", () => TodoRoot(Chunk.empty))
 
   private def deleteDirectory(path: Path): Unit =
     if Files.exists(path) then Files.walk(path).sorted(Comparator.reverseOrder()).forEach(Files.delete)
@@ -121,6 +133,54 @@ object ObjectStoreSpec extends ZIOSpecDefault:
             out.size == 100,
             out.get(1).contains("value-1"),
             out.get(100).contains("value-100"),
+          )
+        }
+      },
+      test("NativeLocal modifies immutable roots, checkpoints, and reloads after restart") {
+        ZIO.scoped {
+          for
+            path <- ZIO.attemptBlocking(Files.createTempFile("native-local-root", ".json"))
+            _    <- ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore
+            _    <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore)
+            layer = NativeLocal.live(path, todoDescriptor)
+            _    <- (for
+                      _ <- ObjectStore.modify[TodoRoot, Unit](root =>
+                             ZIO.succeed(((), root.copy(items = root.items :+ "write docs")))
+                           )
+                      _ <- ObjectStore.checkpoint[TodoRoot]
+                    yield ()).provideLayer(layer)
+            out  <- (for
+                      root <- ObjectStore.load[TodoRoot]
+                    yield root.items.toList).provideLayer(layer)
+          yield assertTrue(out == List("write docs"))
+        }
+      },
+      test("NativeLocal serializes concurrent modify calls and preserves a consistent checkpoint") {
+        ZIO.scoped {
+          given SnapshotCodec[TodoRoot] = SnapshotCodec.json[TodoRoot]
+
+          for
+            path <- ZIO.attemptBlocking(Files.createTempFile("native-local-concurrent", ".json"))
+            _    <- ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore
+            _    <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore)
+            layer = NativeLocal.live(path, todoDescriptor)
+            live <- (for
+                      _ <- ZIO
+                             .foreachPar(1 to 100) { i =>
+                               ObjectStore.modify[TodoRoot, Unit](root =>
+                                 ZIO.succeed(((), root.copy(items = root.items :+ s"task-$i")))
+                               )
+                             }
+                             .withParallelism(16)
+                      _ <- ObjectStore.checkpoint[TodoRoot]
+                      r <- ObjectStore.load[TodoRoot]
+                    yield r).provideLayer(layer)
+            out  <- SnapshotCodec.load(path)
+          yield assertTrue(
+            live.items.size == 100,
+            live.items.toSet == (1 to 100).map(i => s"task-$i").toSet,
+            out.items.size == 100,
+            out.items.toSet == (1 to 100).map(i => s"task-$i").toSet,
           )
         }
       },

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/ObjectStoreSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/ObjectStoreSpec.scala
@@ -1,0 +1,127 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import java.nio.file.{ Files, Path }
+import java.util.Comparator
+import java.util.concurrent.ConcurrentHashMap
+import java.util.{ ArrayList, List as JList }
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfig
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, ObjectStore, Transaction }
+
+object ObjectStoreSpec extends ZIOSpecDefault:
+
+  final class EmployeeDirectory(val employees: JList[String]) extends Serializable
+  final class OrganizationRoot(val departments: JList[EmployeeDirectory]) extends Serializable
+
+  given Tag[EmployeeDirectory] = Tag.derived
+  given Tag[OrganizationRoot]  = Tag.derived
+  given Tag[ConcurrentHashMap[Int, String]] = Tag.derived
+
+  private val organizationDescriptor =
+    RootDescriptor(
+      id = "organization-root",
+      initializer = () =>
+        OrganizationRoot(
+          new ArrayList(
+            List(
+              EmployeeDirectory(new ArrayList(List("alice").asJava)),
+              EmployeeDirectory(new ArrayList(List("carol").asJava)),
+            ).asJava
+          )
+        ),
+    )
+
+  private val counterDescriptor =
+    RootDescriptor.concurrentMap[Int, String]("counter-root")
+
+  private def deleteDirectory(path: Path): Unit =
+    if Files.exists(path) then Files.walk(path).sorted(Comparator.reverseOrder()).forEach(Files.delete)
+
+  private def objectStoreLayer[A: Tag](path: Path, descriptor: RootDescriptor[A]) =
+    ZLayer.succeed(
+      EclipseStoreConfig.make(path).copy(rootDescriptors = Chunk.single(descriptor))
+    ) >>> EclipseStoreService.live >>> ObjectStore.live(descriptor)
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("ObjectStore")(
+      test("fresh store loads typed root, persists mutation, and reloads after checkpoint") {
+        ZIO.scoped {
+          for
+            path <- ZIO.attemptBlocking(Files.createTempDirectory("object-store-root"))
+            _    <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+            layer = objectStoreLayer(path, organizationDescriptor)
+            _    <- (for
+                      root <- ObjectStore.load[OrganizationRoot]
+                      _    <- ZIO.succeed(root.departments.getFirst.employees.add("bob"))
+                      _    <- ObjectStore.storeRoot[OrganizationRoot]
+                      _    <- ObjectStore.checkpoint[OrganizationRoot]
+                    yield ()).provideLayer(layer)
+            out  <- (for
+                      root <- ObjectStore.load[OrganizationRoot]
+                    yield root.departments.getFirst.employees.asScala.toList).provideLayer(layer)
+          yield assertTrue(out == List("alice", "bob"))
+        }
+      },
+      test("storing a subgraph persists only the targeted branch update across restart") {
+        ZIO.scoped {
+          for
+            path <- ZIO.attemptBlocking(Files.createTempDirectory("object-store-subgraph"))
+            _    <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+            layer = objectStoreLayer(path, organizationDescriptor)
+            _    <- (for
+                      root      <- ObjectStore.load[OrganizationRoot]
+                      department = root.departments.getFirst
+                      _         <- ZIO.succeed(department.employees.add("bob"))
+                      _         <- ObjectStore.storeSubgraph[OrganizationRoot](department)
+                    yield ()).provideLayer(layer)
+            out  <- (for
+                      root <- ObjectStore.load[OrganizationRoot]
+                    yield root.departments.asScala.toList.map(_.employees.asScala.toList)).provideLayer(layer)
+          yield assertTrue(
+            out.head == List("alice", "bob"),
+            out(1) == List("carol"),
+          )
+        }
+      },
+      test("serialized transactions keep concurrent mutations consistent across restart") {
+        ZIO.scoped {
+          for
+            path <- ZIO.attemptBlocking(Files.createTempDirectory("object-store-concurrent"))
+            _    <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+            layer = objectStoreLayer(path, counterDescriptor)
+            _    <- ZIO
+                      .foreachPar(1 to 100) { i =>
+                        ObjectStore.transact[ConcurrentHashMap[Int, String], Unit](
+                          Transaction.effect(root =>
+                            ZIO
+                              .attempt(root.put(i, s"value-$i"))
+                              .unit
+                              .mapError(cause =>
+                                EclipseStoreError.StorageError(
+                                  s"Failed to persist concurrent mutation for key $i",
+                                  Some(cause),
+                                )
+                              )
+                          )
+                        )
+                      }
+                      .withParallelism(16)
+                      .provideLayer(layer)
+            out  <- (for
+                      root <- ObjectStore.load[ConcurrentHashMap[Int, String]]
+                    yield root.asScala.toMap).provideLayer(layer)
+          yield assertTrue(
+            out.size == 100,
+            out.get(1).contains("value-1"),
+            out.get(100).contains("value-100"),
+          )
+        }
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/ObjectStoreSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/ObjectStoreSpec.scala
@@ -10,7 +10,7 @@ import zio.*
 import zio.schema.{ DeriveSchema, Schema }
 import zio.test.*
 
-import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfig
+import io.github.riccardomerolla.zio.eclipsestore.config.{ EclipseStoreConfig, NativeLocalSerde }
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 import io.github.riccardomerolla.zio.eclipsestore.service.{
@@ -157,8 +157,6 @@ object ObjectStoreSpec extends ZIOSpecDefault:
       },
       test("NativeLocal serializes concurrent modify calls and preserves a consistent checkpoint") {
         ZIO.scoped {
-          given SnapshotCodec[TodoRoot] = SnapshotCodec.json[TodoRoot]
-
           for
             path <- ZIO.attemptBlocking(Files.createTempFile("native-local-concurrent", ".json"))
             _    <- ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore
@@ -175,7 +173,9 @@ object ObjectStoreSpec extends ZIOSpecDefault:
                       _ <- ObjectStore.checkpoint[TodoRoot]
                       r <- ObjectStore.load[TodoRoot]
                     yield r).provideLayer(layer)
-            out  <- SnapshotCodec.load(path)
+            out  <- SnapshotCodec
+                      .loadEnvelopedOrElse(path, todoDescriptor.id, NativeLocalSerde.Json, TodoRoot(Chunk.empty))
+                      .map(_.value)
           yield assertTrue(
             live.items.size == 100,
             live.items.toSet == (1 to 100).map(i => s"task-$i").toSet,

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/SnapshotCodecSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/SnapshotCodecSpec.scala
@@ -1,0 +1,48 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import zio.*
+import zio.schema.{ DeriveSchema, Schema }
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.SnapshotCodec
+
+object SnapshotCodecSpec extends ZIOSpecDefault:
+
+  final case class Nested(value: Int, label: String)
+  final case class SnapshotRoot(items: Chunk[Nested])
+
+  given Schema[Nested]       = DeriveSchema.gen[Nested]
+  given Schema[SnapshotRoot] = DeriveSchema.gen[SnapshotRoot]
+
+  private val root =
+    SnapshotRoot(
+      Chunk(
+        Nested(1, "alpha"),
+        Nested(2, "beta"),
+      )
+    )
+
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("SnapshotCodec")(
+      test("JSON codec round-trips a whole root") {
+        for
+          encoded <- SnapshotCodec.json[SnapshotRoot].encode(root)
+          decoded <- SnapshotCodec.json[SnapshotRoot].decode(encoded)
+        yield assertTrue(decoded == root)
+      },
+      test("protobuf codec round-trips a whole root") {
+        for
+          encoded <- SnapshotCodec.protobuf[SnapshotRoot].encode(root)
+          decoded <- SnapshotCodec.protobuf[SnapshotRoot].decode(encoded)
+        yield assertTrue(decoded == root)
+      },
+      test("protobuf codec fails with a typed schema error on invalid bytes") {
+        SnapshotCodec.protobuf[SnapshotRoot].decode(Chunk.fromArray("not-protobuf".getBytes)).either.map {
+          case Left(EclipseStoreError.IncompatibleSchemaError(message, _)) =>
+            assertTrue(message.contains("Failed to decode NativeLocal protobuf snapshot payload"))
+          case other                                                       =>
+            assertTrue(other.isLeft)
+        }
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/SnapshotCodecSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/SnapshotCodecSpec.scala
@@ -1,9 +1,12 @@
 package io.github.riccardomerolla.zio.eclipsestore
 
+import java.nio.file.Files
+
 import zio.*
 import zio.schema.{ DeriveSchema, Schema }
 import zio.test.*
 
+import io.github.riccardomerolla.zio.eclipsestore.config.NativeLocalSerde
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 import io.github.riccardomerolla.zio.eclipsestore.service.SnapshotCodec
 
@@ -22,6 +25,14 @@ object SnapshotCodecSpec extends ZIOSpecDefault:
         Nested(2, "beta"),
       )
     )
+
+  private def withTempFile[A](prefix: String, suffix: String)(use: java.nio.file.Path => ZIO[Any, Throwable, A])
+    : ZIO[Any, Throwable, A] =
+    ZIO.scoped {
+      ZIO.acquireRelease(ZIO.attempt(Files.createTempFile(prefix, suffix)))(path =>
+        ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore
+      ).flatMap(use)
+    }
 
   override def spec: Spec[TestEnvironment, Any] =
     suite("SnapshotCodec")(
@@ -43,6 +54,30 @@ object SnapshotCodecSpec extends ZIOSpecDefault:
             assertTrue(message.contains("Failed to decode NativeLocal protobuf snapshot payload"))
           case other                                                       =>
             assertTrue(other.isLeft)
+        }
+      },
+      test("enveloped JSON snapshots round-trip through the NativeLocal envelope format") {
+        withTempFile("snapshot-envelope-json", ".json") { path =>
+          (for
+            _      <- SnapshotCodec.saveEnveloped(path, root, "snapshot-root", NativeLocalSerde.Json)
+            loaded <-
+              SnapshotCodec.loadEnvelopedOrElse(path, "snapshot-root", NativeLocalSerde.Json, SnapshotRoot(Chunk.empty))
+          yield assertTrue(loaded.value == root, !loaded.rewriteRequired)).mapError(err =>
+            new RuntimeException(err.toString)
+          )
+        }
+      },
+      test("legacy raw JSON snapshots still load and request envelope rewrite") {
+        withTempFile("snapshot-legacy-json", ".json") { path =>
+          given SnapshotCodec[SnapshotRoot] = SnapshotCodec.json[SnapshotRoot]
+
+          (for
+            _      <- SnapshotCodec.save(path, root)
+            loaded <-
+              SnapshotCodec.loadEnvelopedOrElse(path, "snapshot-root", NativeLocalSerde.Json, SnapshotRoot(Chunk.empty))
+          yield assertTrue(loaded.value == root, loaded.rewriteRequired)).mapError(err =>
+            new RuntimeException(err.toString)
+          )
         }
       },
     )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageBackendSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageBackendSpec.scala
@@ -7,7 +7,7 @@ import zio.*
 import zio.schema.{ DeriveSchema, Schema }
 import zio.test.*
 
-import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, NativeLocalSerde }
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 import io.github.riccardomerolla.zio.eclipsestore.service.{
@@ -125,6 +125,24 @@ object StorageBackendSpec extends ZIOSpecDefault:
           yield assertTrue(out == NativeCounter(1), exists)
         }
       },
+      test("NativeLocal protobuf backend config wires the shared root services") {
+        ZIO.scoped {
+          for
+            snapshotPath <- ZIO.attemptBlocking(Files.createTempFile("storage-backend-native-local-protobuf", ".pb"))
+            _            <- ZIO.attemptBlocking(Files.deleteIfExists(snapshotPath)).ignore
+            _            <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(snapshotPath)).ignore)
+            layer         = ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath, NativeLocalSerde.Protobuf)) >>>
+                              StorageBackend.rootServices(nativeCounterDescriptor)
+            _            <- (for
+                              _ <- ObjectStore.replace(NativeCounter(7))
+                              _ <- StorageOps.checkpoint[NativeCounter]
+                            yield ()).provideLayer(layer)
+            out          <- ObjectStore.load[NativeCounter].provideLayer(layer)
+            exists       <- ZIO.attemptBlocking(Files.exists(snapshotPath))
+            size         <- ZIO.attemptBlocking(Files.size(snapshotPath))
+          yield assertTrue(out == NativeCounter(7), exists, size > 0L)
+        }
+      },
       test("NativeLocal startup fails with a typed schema error when the snapshot is corrupt") {
         ZIO.scoped {
           for
@@ -137,6 +155,22 @@ object StorageBackendSpec extends ZIOSpecDefault:
           yield built match
             case Left(EclipseStoreError.IncompatibleSchemaError(message, _)) =>
               assertTrue(message.contains("Failed to decode NativeLocal snapshot payload"))
+            case other                                                       =>
+              assertTrue(other.isLeft)
+        }
+      },
+      test("NativeLocal protobuf startup fails with a typed schema error when the snapshot is corrupt") {
+        ZIO.scoped {
+          for
+            snapshotPath <- ZIO.attemptBlocking(Files.createTempFile("storage-backend-native-protobuf-corrupt", ".pb"))
+            _            <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(snapshotPath)).ignore)
+            _            <- ZIO.attemptBlocking(Files.write(snapshotPath, Array[Byte](1, 2, 3, 4, 5)))
+            layer         = ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath, NativeLocalSerde.Protobuf)) >>>
+                              StorageBackend.rootServices(nativeCounterDescriptor)
+            built        <- layer.build.either
+          yield built match
+            case Left(EclipseStoreError.IncompatibleSchemaError(message, _)) =>
+              assertTrue(message.contains("Failed to decode NativeLocal protobuf snapshot payload"))
             case other                                                       =>
               assertTrue(other.isLeft)
         }

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageBackendSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageBackendSpec.scala
@@ -4,13 +4,27 @@ import java.nio.file.{ Files, Path }
 import java.util.Comparator
 
 import zio.*
+import zio.schema.{ DeriveSchema, Schema }
 import zio.test.*
 
 import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
-import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, StorageBackend }
+import io.github.riccardomerolla.zio.eclipsestore.service.{
+  EclipseStoreService,
+  ObjectStore,
+  StorageBackend,
+  StorageOps,
+}
 
 object StorageBackendSpec extends ZIOSpecDefault:
+  final case class NativeCounter(total: Int)
+
+  given Schema[NativeCounter] = DeriveSchema.gen[NativeCounter]
+  given Tag[NativeCounter]    = Tag.derived
+
+  private val nativeCounterDescriptor =
+    RootDescriptor.fromSchema[NativeCounter]("native-counter", () => NativeCounter(0))
 
   private def deleteDirectory(path: Path): UIO[Unit] =
     ZIO.attemptBlocking {
@@ -92,6 +106,39 @@ object StorageBackendSpec extends ZIOSpecDefault:
             yield decoded
 
           assertTrue(roundTrip == Right(config))
+        }
+      },
+      test("NativeLocal backend config wires the shared root services") {
+        ZIO.scoped {
+          for
+            snapshotPath <- ZIO.attemptBlocking(Files.createTempFile("storage-backend-native-local", ".json"))
+            _            <- ZIO.attemptBlocking(Files.deleteIfExists(snapshotPath)).ignore
+            _            <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(snapshotPath)).ignore)
+            layer         = ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath)) >>>
+                              StorageBackend.rootServices(nativeCounterDescriptor)
+            _            <- (for
+                              _ <- ObjectStore.replace(NativeCounter(1))
+                              _ <- StorageOps.checkpoint[NativeCounter]
+                            yield ()).provideLayer(layer)
+            out          <- ObjectStore.load[NativeCounter].provideLayer(layer)
+            exists       <- ZIO.attemptBlocking(Files.exists(snapshotPath))
+          yield assertTrue(out == NativeCounter(1), exists)
+        }
+      },
+      test("NativeLocal startup fails with a typed schema error when the snapshot is corrupt") {
+        ZIO.scoped {
+          for
+            snapshotPath <- ZIO.attemptBlocking(Files.createTempFile("storage-backend-native-corrupt", ".json"))
+            _            <- ZIO.addFinalizer(ZIO.attemptBlocking(Files.deleteIfExists(snapshotPath)).ignore)
+            _            <- ZIO.attemptBlocking(Files.writeString(snapshotPath, "{ this is not valid json"))
+            layer         = ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath)) >>>
+                              StorageBackend.rootServices(nativeCounterDescriptor)
+            built        <- layer.build.either
+          yield built match
+            case Left(EclipseStoreError.IncompatibleSchemaError(message, _)) =>
+              assertTrue(message.contains("Failed to decode NativeLocal snapshot payload"))
+            case other                                                       =>
+              assertTrue(other.isLeft)
         }
       },
     )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageBackendSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageBackendSpec.scala
@@ -1,0 +1,97 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import java.nio.file.{ Files, Path }
+import java.util.Comparator
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.BackendConfig
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, StorageBackend }
+
+object StorageBackendSpec extends ZIOSpecDefault:
+
+  private def deleteDirectory(path: Path): UIO[Unit] =
+    ZIO.attemptBlocking {
+      if Files.exists(path) then
+        Files.walk(path).sorted(Comparator.reverseOrder()).forEach(Files.delete)
+    }.ignore
+
+  private val kvProgram =
+    for
+      _     <- EclipseStoreService.put("backend:key", "backend:value")
+      value <- EclipseStoreService.get[String, String]("backend:key")
+    yield value
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("StorageBackend")(
+      test("switching from in-memory to filesystem backend keeps the same store API available") {
+        ZIO.scoped {
+          for
+            fsDir      <- ZIO.attemptBlocking(Files.createTempDirectory("storage-backend-fs"))
+            _          <- ZIO.addFinalizer(deleteDirectory(fsDir))
+            inMemory   <- kvProgram.provideLayer(
+                            ZLayer.succeed(BackendConfig.InMemory("storage-backend-memory")) >>> StorageBackend.service()
+                          )
+            fileSystem <- kvProgram.provideLayer(
+                            ZLayer.succeed(BackendConfig.FileSystem(fsDir)) >>> StorageBackend.service()
+                          )
+          yield assertTrue(
+            inMemory.contains("backend:value"),
+            fileSystem.contains("backend:value"),
+          )
+        }
+      },
+      test("misconfigured cloud credentials fail the backend layer with a typed auth error") {
+        ZIO.scoped {
+          val layer = ZLayer.succeed(BackendConfig.S3(bucket = "zio-eclipsestore-test")) >>> StorageBackend.live
+          layer.build.either.map {
+            case Left(EclipseStoreError.AuthError(message, _)) =>
+              assertTrue(message.contains("requires accessKey and secretKey"))
+            case other                                         =>
+              assertTrue(other.isLeft)
+          }
+        }
+      },
+      test("sqlite backend remains consistent under concurrent writers and restart") {
+        ZIO.scoped {
+          for
+            sqliteDir <- ZIO.attemptBlocking(Files.createTempDirectory("storage-backend-sqlite"))
+            _         <- ZIO.addFinalizer(deleteDirectory(sqliteDir))
+            layer      = ZLayer.succeed(BackendConfig.Sqlite(sqliteDir.resolve("backend.db"), "backend.db")) >>>
+                           StorageBackend.service()
+            _         <- ZIO
+                           .foreachPar(1 to 50)(i => EclipseStoreService.put(s"key-$i", s"value-$i"))
+                           .withParallelism(8)
+                           .provideLayer(layer)
+            out       <- EclipseStoreService.getAll[String].provideLayer(layer)
+          yield assertTrue(out.toSet == (1 to 50).map(i => s"value-$i").toSet)
+        }
+      },
+      test("durable backend config round-trips across supported discriminators") {
+        val configGen =
+          Gen.oneOf(
+            Gen.int(1, 20).map(i => BackendConfig.FileSystem(Path.of(s"/tmp/backend-fs-$i"))),
+            Gen.int(1, 20).map(i => BackendConfig.MemoryMapped(Path.of(s"/tmp/backend-mmap-$i"))),
+            Gen.int(1, 20).map(i => BackendConfig.InMemory(s"backend-mem-$i")),
+            Gen.int(1, 20).map(i =>
+              BackendConfig.Sqlite(
+                path = Path.of(s"/tmp/backend-sqlite-$i"),
+                storageName = s"backend-$i.db",
+                connectionString = Some(s"jdbc:sqlite:/tmp/backend-sqlite-$i/backend-$i.db"),
+              )
+            ),
+          )
+
+        check(configGen) { config =>
+          val roundTrip =
+            for
+              target  <- config.toStorageTarget
+              decoded <- BackendConfig.fromStorageTarget(target)
+            yield decoded
+
+          assertTrue(roundTrip == Right(config))
+        }
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageLockSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageLockSpec.scala
@@ -1,0 +1,177 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import java.nio.file.{ Files, Path }
+import java.util.Comparator
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfig
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, ObjectStore, StorageLock }
+
+object StorageLockSpec extends ZIOSpecDefault:
+  given Tag[ConcurrentHashMap[String, Int]] = Tag.derived
+
+  private val descriptor =
+    RootDescriptor.concurrentMap[String, Int]("lock-root")
+
+  private def deleteDirectory(path: Path): Unit =
+    if Files.exists(path) then Files.walk(path).sorted(Comparator.reverseOrder()).forEach(Files.delete)
+
+  private def lockLayer(path: Path) =
+    ZLayer.succeed(EclipseStoreConfig.make(path).copy(rootDescriptors = Chunk.single(descriptor))) >>>
+      EclipseStoreService.live >>>
+      ObjectStore.live(descriptor) >>>
+      StorageLock.live[ConcurrentHashMap[String, Int]]
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("StorageLock")(
+      test("many readers complete concurrently with correct values") {
+        ZIO.scoped {
+          for
+            path <- ZIO.attemptBlocking(Files.createTempDirectory("storage-lock-readers"))
+            _    <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+            layer = lockLayer(path)
+            env  <- layer.build
+            _    <- StorageLock.writeLock[ConcurrentHashMap[String, Int], Unit](root =>
+                      ZIO.succeed(root.put("count", 1)).unit
+                    ).provideEnvironment(env)
+            out  <- ZIO
+                      .foreachPar(1 to 20)(_ =>
+                        StorageLock.readLock[ConcurrentHashMap[String, Int], Int](root =>
+                          ZIO.succeed(root.get("count"))
+                        ).provideEnvironment(env)
+                      )
+                      .withParallelism(10)
+          yield assertTrue(out.forall(_ == 1))
+        }
+      },
+      test("writer waits for active readers and then proceeds exclusively") {
+        ZIO.scoped {
+          for
+            path          <- ZIO.attemptBlocking(Files.createTempDirectory("storage-lock-writer"))
+            _             <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+            layer          = lockLayer(path)
+            env           <- layer.build
+            readerEntered <- Promise.make[Nothing, Unit]
+            releaseReader <- Promise.make[Nothing, Unit]
+            readerFiber   <- StorageLock
+                               .readLock[ConcurrentHashMap[String, Int], Int] { root =>
+                                 readerEntered.succeed(()) *> releaseReader.await.as(root.getOrDefault("count", 0))
+                               }
+                               .provideEnvironment(env)
+                               .fork
+            _             <- readerEntered.await
+            writerFiber   <- StorageLock
+                               .writeLock[ConcurrentHashMap[String, Int], Unit](root =>
+                                 ZIO.succeed(root.put("count", 2)).unit
+                               )
+                               .provideEnvironment(env)
+                               .fork
+            writerPoll1   <- writerFiber.poll
+            _             <- releaseReader.succeed(())
+            _             <- readerFiber.join
+            _             <- writerFiber.join
+            finalValue    <- StorageLock
+                               .readLock[ConcurrentHashMap[String, Int], Int](root =>
+                                 ZIO.succeed(root.getOrDefault("count", 0))
+                               )
+                               .provideEnvironment(env)
+          yield assertTrue(writerPoll1.isEmpty, finalValue == 2)
+        }
+      },
+      test("optimisticUpdate retries on conflicts and commits a consistent final state") {
+        ZIO.scoped {
+          for
+            path       <- ZIO.attemptBlocking(Files.createTempDirectory("storage-lock-optimistic"))
+            _          <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+            layer       = lockLayer(path)
+            env        <- layer.build
+            _          <- StorageLock.writeLock[ConcurrentHashMap[String, Int], Unit](root =>
+                            ZIO.succeed(root.put("count", 0)).unit
+                          ).provideEnvironment(env)
+            _          <- ZIO
+                            .foreachPar(1 to 25)(_ =>
+                              StorageLock
+                                .optimisticUpdate[ConcurrentHashMap[String, Int], Int](root =>
+                                  ZIO.succeed(root.getOrDefault("count", 0))
+                                )((root, current) =>
+                                  ZIO.succeed(root.put("count", current + 1)).as(current + 1)
+                                )
+                                .provideEnvironment(env)
+                            )
+                            .withParallelism(8)
+            finalValue <- StorageLock
+                            .readLock[ConcurrentHashMap[String, Int], Int](root =>
+                              ZIO.succeed(root.getOrDefault("count", 0))
+                            )
+                            .provideEnvironment(env)
+          yield assertTrue(finalValue == 25)
+        }
+      },
+      test("interrupted fibers waiting for a lock do not leak the lock") {
+        ZIO.scoped {
+          for
+            path          <- ZIO.attemptBlocking(Files.createTempDirectory("storage-lock-interrupt"))
+            _             <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+            layer          = lockLayer(path)
+            env           <- layer.build
+            releaseWriter <- Promise.make[Nothing, Unit]
+            writerFiber   <- StorageLock
+                               .writeLock[ConcurrentHashMap[String, Int], Unit](_ => releaseWriter.await)
+                               .provideEnvironment(env)
+                               .fork
+            waiter        <- StorageLock
+                               .writeLock[ConcurrentHashMap[String, Int], Unit](root =>
+                                 ZIO.succeed(root.put("count", 1)).unit
+                               )
+                               .provideEnvironment(env)
+                               .fork
+            _             <- TestClock.adjust(100.millis)
+            _             <- waiter.interrupt
+            _             <- releaseWriter.succeed(())
+            _             <- writerFiber.join
+            _             <- StorageLock
+                               .writeLock[ConcurrentHashMap[String, Int], Unit](root =>
+                                 ZIO.succeed(root.put("count", 2)).unit
+                               )
+                               .provideEnvironment(env)
+            finalValue    <- StorageLock
+                               .readLock[ConcurrentHashMap[String, Int], Int](root =>
+                                 ZIO.succeed(root.getOrDefault("count", 0))
+                               )
+                               .provideEnvironment(env)
+          yield assertTrue(finalValue == 2)
+        }
+      },
+      test("failing writes roll the root back to its pre-mutation state") {
+        ZIO.scoped {
+          for
+            path       <- ZIO.attemptBlocking(Files.createTempDirectory("storage-lock-rollback"))
+            _          <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+            layer       = lockLayer(path)
+            env        <- layer.build
+            _          <- StorageLock.writeLock[ConcurrentHashMap[String, Int], Unit](root =>
+                            ZIO.succeed(root.put("count", 1)).unit
+                          ).provideEnvironment(env)
+            _          <- StorageLock
+                            .writeLock[ConcurrentHashMap[String, Int], Unit](root =>
+                              ZIO.succeed(root.put("count", 999)) *>
+                                ZIO.fail(EclipseStoreError.StorageError("boom", None))
+                            )
+                            .provideEnvironment(env)
+                            .either
+            finalValue <- StorageLock
+                            .readLock[ConcurrentHashMap[String, Int], Int](root =>
+                              ZIO.succeed(root.getOrDefault("count", 0))
+                            )
+                            .provideEnvironment(env)
+          yield assertTrue(finalValue == 1)
+        }
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageObservabilitySpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageObservabilitySpec.scala
@@ -1,0 +1,197 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.observability.{ StorageEvent, StorageMetrics, StorageObservability }
+import io.github.riccardomerolla.zio.eclipsestore.service.{
+  LifecycleStatus,
+  ObjectStore,
+  StorageLock,
+  StorageOps,
+  Transaction,
+}
+
+object StorageObservabilitySpec extends ZIOSpecDefault:
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("StorageObservability")(
+      test("instrumented object store preserves behavior and increments persisted counters") {
+        for
+          metrics  <- StorageMetrics.inMemory.build.map(_.get[StorageMetrics])
+          store     = StorageObservability.instrumentObjectStore(
+                        FakeObjectStore(),
+                        metrics,
+                        StorageObservability.Settings(slowOperationThreshold = 5.millis),
+                      )
+          env       = ZEnvironment[ObjectStore[ConcurrentHashMap[String, Int]]](store)
+          result   <- ObjectStore
+                        .transact[ConcurrentHashMap[String, Int], Int](
+                          Transaction.effect(root =>
+                            ZIO.succeed {
+                              root.put("a", 1)
+                              root.size()
+                            }
+                          )
+                        )
+                        .provideEnvironment(env)
+          snapshot <- StorageMetrics.snapshot.provideEnvironment(ZEnvironment(metrics))
+        yield assertTrue(
+          result == 1,
+          snapshot.persistedObjects == 1L,
+          snapshot.operationCounts.get("object-store.transact.success").contains(1L),
+        )
+      },
+      test("slow storage operations emit duration metrics and slow events") {
+        for
+          metrics  <- StorageMetrics.inMemory.build.map(_.get[StorageMetrics])
+          ops       = StorageObservability.instrumentStorageOps(
+                        FakeStorageOps(),
+                        metrics,
+                        StorageObservability.Settings(slowOperationThreshold = 10.millis),
+                      )
+          env       = ZEnvironment[StorageOps[ConcurrentHashMap[String, String]]](ops)
+          _        <- StorageOps
+                        .backup[ConcurrentHashMap[String, String]](Path.of("/tmp/backup"))
+                        .provideEnvironment(env)
+          _        <- StorageOps.housekeep[ConcurrentHashMap[String, String]].provideEnvironment(env)
+          snapshot <- StorageMetrics.snapshot.provideEnvironment(ZEnvironment(metrics))
+        yield assertTrue(
+          snapshot.latestDurationGaugeMillis.contains("storage-ops.backup"),
+          snapshot.latestDurationGaugeMillis.contains("storage-ops.housekeep"),
+          snapshot.events.exists {
+            case StorageEvent.SlowOperationDetected("storage-ops.backup", _, _)    => true
+            case StorageEvent.SlowOperationDetected("storage-ops.housekeep", _, _) => true
+            case _                                                                 => false
+          },
+        )
+      },
+      test("failed operations preserve typed errors and are recorded") {
+        for
+          metrics  <- StorageMetrics.inMemory.build.map(_.get[StorageMetrics])
+          ops       = StorageObservability.instrumentStorageOps(
+                        FakeStorageOps(),
+                        metrics,
+                        StorageObservability.Settings(slowOperationThreshold = 10.millis),
+                      )
+          env       = ZEnvironment[StorageOps[ConcurrentHashMap[String, String]]](ops)
+          result   <- StorageOps
+                        .exportTo[ConcurrentHashMap[String, String]](Path.of("/tmp/export"))
+                        .provideEnvironment(env)
+                        .either
+          snapshot <- StorageMetrics.snapshot.provideEnvironment(ZEnvironment(metrics))
+        yield assertTrue(
+          result == Left(EclipseStoreError.StorageError("export failed", None)),
+          snapshot.failedOperations == 1L,
+          snapshot.operationCounts.get("storage-ops.export.failure").contains(1L),
+        )
+      },
+      test("heavy write-lock contention records contention events") {
+        ZIO.scoped {
+          for
+            metrics  <- StorageMetrics.inMemory.build.map(_.get[StorageMetrics])
+            lock      =
+              StorageObservability.instrumentStorageLock(
+                FakeStorageLock(),
+                metrics,
+                StorageObservability.Settings(slowOperationThreshold = 10.millis, lockContentionThreshold = 10.millis),
+              )
+            env       = ZEnvironment[StorageLock[ConcurrentHashMap[String, Int]]](lock)
+            _        <- StorageLock
+                          .writeLock[ConcurrentHashMap[String, Int], Unit](_ => TestClock.adjust(50.millis))
+                          .provideEnvironment(env)
+            snapshot <- StorageMetrics.snapshot.provideEnvironment(ZEnvironment(metrics))
+          yield assertTrue(
+            snapshot.lockContentionEvents >= 1L,
+            snapshot.events.exists {
+              case StorageEvent.LockContentionDetected("storage-lock.write", _, _) => true
+              case _                                                               => false
+            },
+          )
+        }
+      },
+    )
+
+final private case class FakeObjectStore() extends ObjectStore[ConcurrentHashMap[String, Int]]:
+  override val descriptor: RootDescriptor[ConcurrentHashMap[String, Int]] =
+    RootDescriptor.concurrentMap[String, Int]("obs-root")
+  private val root                                                        = new ConcurrentHashMap[String, Int]()
+
+  override def load: IO[EclipseStoreError, ConcurrentHashMap[String, Int]] =
+    ZIO.succeed(root)
+
+  override def storeSubgraph(subgraph: AnyRef): IO[EclipseStoreError, Unit] =
+    ZIO.unit
+
+  override def storeRoot: IO[EclipseStoreError, Unit] =
+    ZIO.unit
+
+  override def checkpoint: IO[EclipseStoreError, Unit] =
+    ZIO.unit
+
+  override def transact[A](transaction: Transaction[ConcurrentHashMap[String, Int], A]): IO[EclipseStoreError, A] =
+    transaction.run(root)
+
+final private case class FakeStorageOps() extends StorageOps[ConcurrentHashMap[String, String]]:
+  override val descriptor: RootDescriptor[ConcurrentHashMap[String, String]] =
+    RootDescriptor.concurrentMap[String, String]("ops-root")
+  private val root                                                           = new ConcurrentHashMap[String, String]()
+
+  override def load: IO[EclipseStoreError, ConcurrentHashMap[String, String]] =
+    ZIO.succeed(root)
+
+  override val status: UIO[LifecycleStatus] =
+    Clock.instant.map(LifecycleStatus.Running(_))
+
+  override def checkpoint: IO[EclipseStoreError, LifecycleStatus] =
+    status
+
+  override def backup(target: Path, includeConfig: Boolean = true): IO[EclipseStoreError, LifecycleStatus] =
+    TestClock.adjust(20.millis) *> status
+
+  override def exportTo(target: Path): IO[EclipseStoreError, LifecycleStatus] =
+    ZIO.fail(EclipseStoreError.StorageError("export failed", None))
+
+  override def importFrom(source: Path): IO[EclipseStoreError, LifecycleStatus] =
+    status
+
+  override def restoreFrom(source: Path): IO[EclipseStoreError, LifecycleStatus] =
+    status
+
+  override def restart: IO[EclipseStoreError, LifecycleStatus] =
+    status
+
+  override def shutdown: IO[EclipseStoreError, LifecycleStatus] =
+    ZIO.succeed(LifecycleStatus.Stopped)
+
+  override def housekeep: IO[EclipseStoreError, LifecycleStatus] =
+    TestClock.adjust(25.millis) *> status
+
+  override def scheduleCheckpoints(schedule: Schedule[Any, Any, Any]): URIO[Scope, Fiber.Runtime[Nothing, Unit]] =
+    ZIO.unit.forkScoped
+
+final private case class FakeStorageLock() extends StorageLock[ConcurrentHashMap[String, Int]]:
+  private val root = new ConcurrentHashMap[String, Int]()
+
+  override def readLock[A](effect: ConcurrentHashMap[String, Int] => IO[EclipseStoreError, A])
+    : IO[EclipseStoreError, A] =
+    effect(root)
+
+  override def writeLock[A](effect: ConcurrentHashMap[String, Int] => IO[EclipseStoreError, A])
+    : IO[EclipseStoreError, A] =
+    effect(root)
+
+  override def optimisticUpdate[A](
+    prepare: ConcurrentHashMap[String, Int] => IO[EclipseStoreError, A]
+  )(
+    commit: (ConcurrentHashMap[String, Int], A) => IO[EclipseStoreError, A],
+    maxRetries: Int = 8,
+  ): IO[EclipseStoreError, A] =
+    for
+      prepared <- prepare(root)
+      result   <- commit(root, prepared)
+    yield result

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageObservabilitySpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageObservabilitySpec.scala
@@ -124,6 +124,17 @@ final private case class FakeObjectStore() extends ObjectStore[ConcurrentHashMap
   override def load: IO[EclipseStoreError, ConcurrentHashMap[String, Int]] =
     ZIO.succeed(root)
 
+  override def replace(root: ConcurrentHashMap[String, Int]): IO[EclipseStoreError, Unit] =
+    ZIO.succeed {
+      this.root.clear()
+      this.root.putAll(root)
+    }
+
+  override def modify[A](
+    f: ConcurrentHashMap[String, Int] => IO[EclipseStoreError, (A, ConcurrentHashMap[String, Int])]
+  ): IO[EclipseStoreError, A] =
+    f(root).flatMap { case (result, updated) => replace(updated).as(result) }
+
   override def storeSubgraph(subgraph: AnyRef): IO[EclipseStoreError, Unit] =
     ZIO.unit
 

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageOpsSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageOpsSpec.scala
@@ -204,6 +204,39 @@ object StorageOpsSpec extends ZIOSpecDefault:
           )
         }
       },
+      test("NativeLocal scheduled checkpoints persist immutable roots after simulated time advances") {
+        ZIO.scoped {
+          for
+            snapshotDir <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-native-scheduled"))
+            _           <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(snapshotDir)).orDie)
+            snapshotPath = snapshotDir.resolve("root.json")
+            before      <- ZIO.scoped {
+                             for
+                               env      <- nativeLayer(snapshotPath).build
+                               scopeEnv <- ZIO.environment[Scope]
+                               _        <- StorageOps
+                                             .scheduleCheckpoints[NativeNotes](Schedule.spaced(1.hour))
+                                             .provideEnvironment(scopeEnv ++ env)
+                               _        <- ObjectStore
+                                             .replace(NativeNotes(Chunk("scheduled-native-local")))
+                                             .provideEnvironment(env)
+                               before   <- StorageOps
+                                             .load[NativeNotes]
+                                             .provideLayer(nativeLayer(snapshotPath).fresh)
+                               _        <- TestClock.adjust(1.hour)
+                             yield before
+                           }
+            after       <- StorageOps.load[NativeNotes].provideLayer(nativeLayer(snapshotPath).fresh)
+            status      <- StorageOps.status.provideLayer(nativeLayer(snapshotPath))
+          yield assertTrue(
+            before == NativeNotes(Chunk.empty),
+            after == NativeNotes(Chunk("scheduled-native-local")),
+            status match
+              case LifecycleStatus.Running(_) => true
+              case _                          => false,
+          )
+        }
+      },
       test("NativeLocal shutdown persists the final snapshot before stopping") {
         ZIO.scoped {
           for

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageOpsSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageOpsSpec.scala
@@ -5,16 +5,24 @@ import java.util.Comparator
 import java.util.concurrent.ConcurrentHashMap
 
 import zio.*
+import zio.schema.{ DeriveSchema, Schema }
 import zio.test.*
 
-import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfig
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, EclipseStoreConfig }
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
-import io.github.riccardomerolla.zio.eclipsestore.service.{ LifecycleStatus, StorageOps }
+import io.github.riccardomerolla.zio.eclipsestore.service.{ LifecycleStatus, ObjectStore, StorageBackend, StorageOps }
 
 object StorageOpsSpec extends ZIOSpecDefault:
+  final case class NativeNotes(notes: Chunk[String])
+
+  given Schema[NativeNotes] = DeriveSchema.gen[NativeNotes]
+  given Tag[NativeNotes]    = Tag.derived
 
   private val rootDescriptor =
     RootDescriptor.concurrentMap[String, String]("storage-ops-root")
+
+  private val nativeDescriptor =
+    RootDescriptor.fromSchema[NativeNotes]("native-storage-ops-root", () => NativeNotes(Chunk.empty))
 
   private def deleteDirectory(path: Path): Unit =
     if Files.exists(path) then Files.walk(path).sorted(Comparator.reverseOrder()).forEach(Files.delete)
@@ -23,6 +31,9 @@ object StorageOpsSpec extends ZIOSpecDefault:
     ZLayer.succeed(EclipseStoreConfig.make(path).copy(rootDescriptors = Chunk.single(rootDescriptor))) >>>
       io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService.live >>>
       StorageOps.live(rootDescriptor)
+
+  private def nativeLayer(snapshotPath: Path) =
+    ZLayer.succeed(BackendConfig.NativeLocal(snapshotPath)) >>> StorageBackend.rootServices(nativeDescriptor)
 
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("StorageOps")(
@@ -141,6 +152,72 @@ object StorageOpsSpec extends ZIOSpecDefault:
               case LifecycleStatus.Running(_) => true
               case _                          => false,
             reopened.contains("yes"),
+          )
+        }
+      },
+      test("NativeLocal export/import preserves immutable roots through StorageOps") {
+        ZIO.scoped {
+          for
+            snapshotDir <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-native"))
+            exportedDir <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-native-export"))
+            restoredDir <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-native-restored"))
+            _           <- ZIO.addFinalizer(
+                             ZIO.attemptBlocking {
+                               deleteDirectory(snapshotDir)
+                               deleteDirectory(exportedDir)
+                               deleteDirectory(restoredDir)
+                             }.orDie
+                           )
+            snapshotPath = snapshotDir.resolve("root.json")
+            exportPath   = exportedDir.resolve("export.json")
+            restorePath  = restoredDir.resolve("root.json")
+            _           <- (for
+                             _ <- ObjectStore.replace(NativeNotes(Chunk("a", "b")))
+                             _ <- StorageOps.exportTo[NativeNotes](exportPath)
+                           yield ()).provideLayer(nativeLayer(snapshotPath))
+            imported    <- (for
+                             _    <- StorageOps.importFrom[NativeNotes](exportPath)
+                             root <- StorageOps.load[NativeNotes]
+                           yield root).provideLayer(nativeLayer(restorePath))
+          yield assertTrue(imported == NativeNotes(Chunk("a", "b")))
+        }
+      },
+      test("NativeLocal restart and housekeep keep checkpointed immutable roots available") {
+        ZIO.scoped {
+          for
+            snapshotDir <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-native-restart"))
+            _           <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(snapshotDir)).orDie)
+            snapshotPath = snapshotDir.resolve("root.json")
+            status      <- (for
+                             _      <- ObjectStore.replace(NativeNotes(Chunk("kept")))
+                             _      <- StorageOps.checkpoint[NativeNotes]
+                             _      <- ObjectStore.replace(NativeNotes(Chunk("transient")))
+                             status <- StorageOps.restart[NativeNotes]
+                             _      <- StorageOps.housekeep[NativeNotes]
+                           yield status).provideLayer(nativeLayer(snapshotPath))
+            reopened    <- StorageOps.load[NativeNotes].provideLayer(nativeLayer(snapshotPath))
+          yield assertTrue(
+            status match
+              case LifecycleStatus.Running(_) => true
+              case _                          => false,
+            reopened == NativeNotes(Chunk("kept")),
+          )
+        }
+      },
+      test("NativeLocal shutdown persists the final snapshot before stopping") {
+        ZIO.scoped {
+          for
+            snapshotDir <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-native-shutdown"))
+            _           <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(snapshotDir)).orDie)
+            snapshotPath = snapshotDir.resolve("root.json")
+            status      <- (for
+                             _      <- ObjectStore.replace(NativeNotes(Chunk("persisted-on-shutdown")))
+                             status <- StorageOps.shutdown[NativeNotes]
+                           yield status).provideLayer(nativeLayer(snapshotPath))
+            reopened    <- StorageOps.load[NativeNotes].provideLayer(nativeLayer(snapshotPath))
+          yield assertTrue(
+            status == LifecycleStatus.Stopped,
+            reopened == NativeNotes(Chunk("persisted-on-shutdown")),
           )
         }
       },

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageOpsSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/StorageOpsSpec.scala
@@ -1,0 +1,147 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import java.nio.file.{ Files, Path }
+import java.util.Comparator
+import java.util.concurrent.ConcurrentHashMap
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfig
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.service.{ LifecycleStatus, StorageOps }
+
+object StorageOpsSpec extends ZIOSpecDefault:
+
+  private val rootDescriptor =
+    RootDescriptor.concurrentMap[String, String]("storage-ops-root")
+
+  private def deleteDirectory(path: Path): Unit =
+    if Files.exists(path) then Files.walk(path).sorted(Comparator.reverseOrder()).forEach(Files.delete)
+
+  private def opsLayer(path: Path) =
+    ZLayer.succeed(EclipseStoreConfig.make(path).copy(rootDescriptors = Chunk.single(rootDescriptor))) >>>
+      io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService.live >>>
+      StorageOps.live(rootDescriptor)
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("StorageOps")(
+      test("backup then restore reconstructs the original typed root graph") {
+        ZIO.scoped {
+          for
+            primary   <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-primary"))
+            backup    <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-backup"))
+            restored  <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-restored"))
+            _         <- ZIO.addFinalizer(
+                           ZIO.attemptBlocking {
+                             deleteDirectory(primary)
+                             deleteDirectory(backup)
+                             deleteDirectory(restored)
+                           }.orDie
+                         )
+            _         <- (for
+                           root <- StorageOps.load[ConcurrentHashMap[String, String]]
+                           _    <- ZIO.succeed {
+                                     root.put("user-1", "alice")
+                                     root.put("user-2", "bob")
+                                   }
+                           _    <- StorageOps.checkpoint[ConcurrentHashMap[String, String]]
+                           _    <- StorageOps.backup[ConcurrentHashMap[String, String]](backup)
+                         yield ()).provideLayer(opsLayer(primary))
+            roundTrip <- (for
+                           _    <- StorageOps.restoreFrom[ConcurrentHashMap[String, String]](backup)
+                           root <- StorageOps.load[ConcurrentHashMap[String, String]]
+                         yield Map(
+                           "user-1" -> Option(root.get("user-1")),
+                           "user-2" -> Option(root.get("user-2")),
+                         )).provideLayer(opsLayer(restored))
+          yield assertTrue(roundTrip == Map("user-1" -> Some("alice"), "user-2" -> Some("bob")))
+        }
+      },
+      test("export/import keeps the root accessible through Scala-native APIs") {
+        ZIO.scoped {
+          for
+            primary  <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-export-primary"))
+            exported <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-exported"))
+            restored <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-import-restored"))
+            _        <- ZIO.addFinalizer(
+                          ZIO.attemptBlocking {
+                            deleteDirectory(primary)
+                            deleteDirectory(exported)
+                            deleteDirectory(restored)
+                          }.orDie
+                        )
+            _        <- (for
+                          root <- StorageOps.load[ConcurrentHashMap[String, String]]
+                          _    <- ZIO.succeed {
+                                    root.put("user-3", "carol")
+                                    root.put("user-4", "dave")
+                                  }
+                          _    <- StorageOps.checkpoint[ConcurrentHashMap[String, String]]
+                          _    <- StorageOps.exportTo[ConcurrentHashMap[String, String]](exported)
+                        yield ()).provideLayer(opsLayer(primary))
+            imported <- (for
+                          _    <- StorageOps.importFrom[ConcurrentHashMap[String, String]](exported)
+                          root <- StorageOps.load[ConcurrentHashMap[String, String]]
+                        yield Map(
+                          "user-3" -> Option(root.get("user-3")),
+                          "user-4" -> Option(root.get("user-4")),
+                        )).provideLayer(opsLayer(restored))
+          yield assertTrue(imported == Map("user-3" -> Some("carol"), "user-4" -> Some("dave")))
+        }
+      },
+      test("scheduled checkpoints persist in-memory root mutations after simulated time advances") {
+        ZIO.scoped {
+          for
+            path   <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-scheduled"))
+            _      <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+            before <- ZIO.scoped {
+                        for
+                          env      <- opsLayer(path).build
+                          scopeEnv <- ZIO.environment[Scope]
+                          _        <- StorageOps
+                                        .scheduleCheckpoints[ConcurrentHashMap[String, String]](Schedule.spaced(1.hour))
+                                        .provideEnvironment(scopeEnv ++ env)
+                          root     <- StorageOps.load[ConcurrentHashMap[String, String]].provideEnvironment(env)
+                          _        <- ZIO.succeed(root.put("scheduled", "true"))
+                          before   <- StorageOps
+                                        .load[ConcurrentHashMap[String, String]]
+                                        .provideLayer(opsLayer(path).fresh)
+                                        .map(root => Option(root.get("scheduled")))
+                                        .either
+                          _        <- TestClock.adjust(1.hour)
+                        yield before
+                      }
+            after  <- StorageOps
+                        .load[ConcurrentHashMap[String, String]]
+                        .provideLayer(opsLayer(path).fresh)
+                        .map(root => Option(root.get("scheduled")))
+          yield assertTrue(before.isLeft, after.contains("true"))
+        }
+      },
+      test("housekeeping checkpoints and reloads the configured root") {
+        ZIO.scoped {
+          for
+            path     <- ZIO.attemptBlocking(Files.createTempDirectory("storage-ops-housekeep"))
+            _        <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+            status   <- ZIO.scoped {
+                          for
+                            env    <- opsLayer(path).build
+                            root   <- StorageOps.load[ConcurrentHashMap[String, String]].provideEnvironment(env)
+                            _      <- ZIO.succeed(root.put("retained", "yes"))
+                            status <- StorageOps.housekeep[ConcurrentHashMap[String, String]].provideEnvironment(env)
+                          yield status
+                        }
+            reopened <- StorageOps
+                          .load[ConcurrentHashMap[String, String]]
+                          .provideLayer(opsLayer(path).fresh)
+                          .map(root => Option(root.get("retained")))
+          yield assertTrue(
+            status match
+              case LifecycleStatus.Running(_) => true
+              case _                          => false,
+            reopened.contains("yes"),
+          )
+        }
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/TestkitSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/TestkitSpec.scala
@@ -8,13 +8,20 @@ import scala.jdk.CollectionConverters.*
 
 import zio.*
 import zio.schema.{ DeriveSchema, Schema }
+import zio.stm.STM
 import zio.test.*
 
 import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfig
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 import io.github.riccardomerolla.zio.eclipsestore.schema.TypedStore
-import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, ObjectStore, StorageOps, Transaction }
+import io.github.riccardomerolla.zio.eclipsestore.service.{
+  EclipseStoreService,
+  NativeLocalSTM,
+  ObjectStore,
+  StorageOps,
+  Transaction,
+}
 import io.github.riccardomerolla.zio.eclipsestore.testkit.*
 
 object TestkitSpec extends ZIOSpecDefault:
@@ -158,6 +165,33 @@ object TestkitSpec extends ZIOSpecDefault:
                                 ObjectStore.modify[NativeEventLog, Unit](root =>
                                   ZIO.succeed(((), root.copy(events = root.events :+ event)))
                                 )
+                              }
+                         _ <- StorageOps.checkpoint[NativeEventLog]
+                         _ <- StorageOps.restart[NativeEventLog]
+                         r <- ObjectStore.load[NativeEventLog]
+                       yield r).provideEnvironment(env)
+              yield r
+            },
+            baseline = ZIO.succeed(expected),
+          ) { (live, model) =>
+            assertTrue(live == model, live.events == events)
+          }
+        }
+      },
+      test("NativeLocal STM temp layer supports model-vs-engine immutable root sequences") {
+        check(Gen.chunkOfBounded(1, 8)(PersistenceGenerators.messageEvent)) { events =>
+          val expected = NativeEventLog(events)
+
+          PersistenceSpec.compare(
+            live = ZIO.scoped {
+              for
+                env <- NativeLocalObjectStore.tempLayerWithSTM(nativeEventLogDescriptor).build
+                r   <- (for
+                         _ <- ZIO.foreachDiscard(events) { event =>
+                                NativeLocalSTM.atomically[NativeEventLog, Unit] { ref =>
+                                  ref.update(root => root.copy(events = root.events :+ event)) *>
+                                    STM.unit
+                                }
                               }
                          _ <- StorageOps.checkpoint[NativeEventLog]
                          _ <- StorageOps.restart[NativeEventLog]

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/TestkitSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/TestkitSpec.scala
@@ -1,0 +1,146 @@
+package io.github.riccardomerolla.zio.eclipsestore
+
+import java.nio.file.{ Files, Path }
+import java.util.Comparator
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.schema.Schema
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfig
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.schema.TypedStore
+import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, ObjectStore, Transaction }
+import io.github.riccardomerolla.zio.eclipsestore.testkit.{
+  BddScenario,
+  FaultInjector,
+  InMemoryObjectStore,
+  PersistenceGenerators,
+  PersistenceSpec,
+}
+
+object TestkitSpec extends ZIOSpecDefault:
+  private val mapDescriptor =
+    RootDescriptor.concurrentMap[String, String]("testkit-root")
+
+  private def deleteDirectory(path: Path): Unit =
+    if Files.exists(path) then Files.walk(path).sorted(Comparator.reverseOrder()).forEach(Files.delete)
+
+  private def liveObjectStoreLayer(path: Path) =
+    ZLayer.succeed(EclipseStoreConfig.make(path).copy(rootDescriptors = Chunk.single(mapDescriptor))) >>>
+      EclipseStoreService.live >>>
+      ObjectStore.live(mapDescriptor)
+
+  private def inMemoryObjectStoreLayer =
+    InMemoryObjectStore.layer(mapDescriptor)
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("Testkit")(
+      BddScenario
+        .scenario("PersistenceSpec parity")
+        .`given`("a live and in-memory object store contract")(
+          ZIO.unit
+        )
+        .when("the same read/write program runs through both implementations") {
+          ZIO.scoped {
+            for
+              path <- ZIO.attemptBlocking(Files.createTempDirectory("testkit-live-store")).orDie
+              _    <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+              live <- ObjectStore
+                        .transact[ConcurrentHashMap[String, String], Map[String, String]](
+                          Transaction.effect(root =>
+                            ZIO.succeed {
+                              root.put("alpha", "1")
+                              root.put("beta", "2")
+                              root.asScala.toMap
+                            }
+                          )
+                        )
+                        .provideLayer(liveObjectStoreLayer(path))
+              mem  <- ObjectStore
+                        .transact[ConcurrentHashMap[String, String], Map[String, String]](
+                          Transaction.effect(root =>
+                            ZIO.succeed {
+                              root.put("alpha", "1")
+                              root.put("beta", "2")
+                              root.asScala.toMap
+                            }
+                          )
+                        )
+                        .provideLayer(inMemoryObjectStoreLayer)
+            yield (live, mem)
+          }
+        }
+        .thenAssert("data persists according to the same behavioral contract") {
+          case (live, mem) =>
+            assertTrue(
+              live == mem,
+              live == Map("alpha" -> "1", "beta" -> "2"),
+            )
+        }
+        .spec,
+      test("fault injector cleans up and reports configured failures") {
+        ZIO.scoped {
+          for
+            injector <- FaultInjector.inMemory.build.map(_.get[FaultInjector])
+            cleaned  <- Ref.make(false)
+            _        <- FaultInjector
+                          .failNext(
+                            operation = "backup",
+                            error = EclipseStoreError.ResourceError("boom", None),
+                            cleanup = cleaned.set(true),
+                          )
+                          .provideEnvironment(ZEnvironment(injector))
+            result   <- FaultInjector
+                          .inject("backup")(ZIO.succeed("ok"))
+                          .provideEnvironment(ZEnvironment(injector))
+                          .either
+            triggered <- FaultInjector.triggeredOperations.provideEnvironment(ZEnvironment(injector))
+            cleanuped <- cleaned.get
+          yield assertTrue(
+            result == Left(EclipseStoreError.ResourceError("boom", None)),
+            cleanuped,
+            triggered == Chunk("backup"),
+          )
+        }
+      },
+      test("schema-derived fixtures satisfy the same typed store contract in-memory and live") {
+        check(PersistenceGenerators.messageEvent) { event =>
+          ZIO.scoped {
+            for
+              path <- ZIO.attemptBlocking(Files.createTempDirectory("testkit-typed-store")).orDie
+              _    <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+              liveLayer =
+                ZLayer.succeed(EclipseStoreConfig.make(path)) >>>
+                  TypedStore.handlersFor[String, PersistenceGenerators.MessageEvent] >>>
+                  EclipseStoreService.live >>>
+                  TypedStore.live
+              memLayer =
+                EclipseStoreService.inMemory >>> TypedStore.live
+              liveSpec =
+                for {
+                  _      <- TypedStore.store("evt", event)
+                  loaded <- TypedStore.fetch[String, PersistenceGenerators.MessageEvent]("evt")
+                } yield loaded
+              memorySpec =
+                for {
+                  _      <- TypedStore.store("evt", event)
+                  loaded <- TypedStore.fetch[String, PersistenceGenerators.MessageEvent]("evt")
+                } yield loaded
+              live      <- liveSpec.provideLayer(liveLayer)
+              inMemory  <- memorySpec.provideLayer(memLayer)
+            yield assertTrue(live == inMemory, live.contains(event))
+          }
+        }
+      },
+      PersistenceSpec.parity("generic parity helper supports shared contract suites")(
+        ZIO.succeed(Chunk("live", "contract")),
+        ZIO.succeed(Chunk("live", "contract")),
+      ) { (live, inMemory) =>
+        assertTrue(live == inMemory)
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/TestkitSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/TestkitSpec.scala
@@ -7,25 +7,27 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters.*
 
 import zio.*
-import zio.schema.Schema
+import zio.schema.{ DeriveSchema, Schema }
 import zio.test.*
 
 import io.github.riccardomerolla.zio.eclipsestore.config.EclipseStoreConfig
 import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
 import io.github.riccardomerolla.zio.eclipsestore.schema.TypedStore
-import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, ObjectStore, Transaction }
-import io.github.riccardomerolla.zio.eclipsestore.testkit.{
-  BddScenario,
-  FaultInjector,
-  InMemoryObjectStore,
-  PersistenceGenerators,
-  PersistenceSpec,
-}
+import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, ObjectStore, StorageOps, Transaction }
+import io.github.riccardomerolla.zio.eclipsestore.testkit.*
 
 object TestkitSpec extends ZIOSpecDefault:
+  final case class NativeEventLog(events: Chunk[PersistenceGenerators.MessageEvent])
+
+  given Schema[NativeEventLog] = DeriveSchema.gen[NativeEventLog]
+  given Tag[NativeEventLog]    = Tag.derived
+
   private val mapDescriptor =
     RootDescriptor.concurrentMap[String, String]("testkit-root")
+
+  private val nativeEventLogDescriptor =
+    RootDescriptor.fromSchema[NativeEventLog]("native-event-log", () => NativeEventLog(Chunk.empty))
 
   private def deleteDirectory(path: Path): Unit =
     if Files.exists(path) then Files.walk(path).sorted(Comparator.reverseOrder()).forEach(Files.delete)
@@ -86,19 +88,19 @@ object TestkitSpec extends ZIOSpecDefault:
       test("fault injector cleans up and reports configured failures") {
         ZIO.scoped {
           for
-            injector <- FaultInjector.inMemory.build.map(_.get[FaultInjector])
-            cleaned  <- Ref.make(false)
-            _        <- FaultInjector
-                          .failNext(
-                            operation = "backup",
-                            error = EclipseStoreError.ResourceError("boom", None),
-                            cleanup = cleaned.set(true),
-                          )
-                          .provideEnvironment(ZEnvironment(injector))
-            result   <- FaultInjector
-                          .inject("backup")(ZIO.succeed("ok"))
-                          .provideEnvironment(ZEnvironment(injector))
-                          .either
+            injector  <- FaultInjector.inMemory.build.map(_.get[FaultInjector])
+            cleaned   <- Ref.make(false)
+            _         <- FaultInjector
+                           .failNext(
+                             operation = "backup",
+                             error = EclipseStoreError.ResourceError("boom", None),
+                             cleanup = cleaned.set(true),
+                           )
+                           .provideEnvironment(ZEnvironment(injector))
+            result    <- FaultInjector
+                           .inject("backup")(ZIO.succeed("ok"))
+                           .provideEnvironment(ZEnvironment(injector))
+                           .either
             triggered <- FaultInjector.triggeredOperations.provideEnvironment(ZEnvironment(injector))
             cleanuped <- cleaned.get
           yield assertTrue(
@@ -112,16 +114,16 @@ object TestkitSpec extends ZIOSpecDefault:
         check(PersistenceGenerators.messageEvent) { event =>
           ZIO.scoped {
             for
-              path <- ZIO.attemptBlocking(Files.createTempDirectory("testkit-typed-store")).orDie
-              _    <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
-              liveLayer =
+              path      <- ZIO.attemptBlocking(Files.createTempDirectory("testkit-typed-store")).orDie
+              _         <- ZIO.addFinalizer(ZIO.attemptBlocking(deleteDirectory(path)).orDie)
+              liveLayer  =
                 ZLayer.succeed(EclipseStoreConfig.make(path)) >>>
                   TypedStore.handlersFor[String, PersistenceGenerators.MessageEvent] >>>
                   EclipseStoreService.live >>>
                   TypedStore.live
-              memLayer =
+              memLayer   =
                 EclipseStoreService.inMemory >>> TypedStore.live
-              liveSpec =
+              liveSpec   =
                 for {
                   _      <- TypedStore.store("evt", event)
                   loaded <- TypedStore.fetch[String, PersistenceGenerators.MessageEvent]("evt")
@@ -142,5 +144,31 @@ object TestkitSpec extends ZIOSpecDefault:
         ZIO.succeed(Chunk("live", "contract")),
       ) { (live, inMemory) =>
         assertTrue(live == inMemory)
+      },
+      test("NativeLocal temp layer supports model-vs-engine immutable root sequences") {
+        check(Gen.chunkOfBounded(1, 8)(PersistenceGenerators.messageEvent)) { events =>
+          val expected = NativeEventLog(events)
+
+          PersistenceSpec.compare(
+            live = ZIO.scoped {
+              for
+                env <- NativeLocalObjectStore.tempLayer(nativeEventLogDescriptor).build
+                r   <- (for
+                         _ <- ZIO.foreachDiscard(events) { event =>
+                                ObjectStore.modify[NativeEventLog, Unit](root =>
+                                  ZIO.succeed(((), root.copy(events = root.events :+ event)))
+                                )
+                              }
+                         _ <- StorageOps.checkpoint[NativeEventLog]
+                         _ <- StorageOps.restart[NativeEventLog]
+                         r <- ObjectStore.load[NativeEventLog]
+                       yield r).provideEnvironment(env)
+              yield r
+            },
+            baseline = ZIO.succeed(expected),
+          ) { (live, model) =>
+            assertTrue(live == model, live.events == events)
+          }
+        }
       },
     )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/config/EclipseStoreConfigZIOSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/config/EclipseStoreConfigZIOSpec.scala
@@ -69,4 +69,27 @@ object EclipseStoreConfigZIOSpec extends ZIOSpecDefault:
           config = env.get[BackendConfig]
         yield assertTrue(config == BackendConfig.NativeLocal(Path.of("/tmp/zio-eclipsestore-native-local.snapshot")))
       },
+      test("loads NativeLocal protobuf serde from backend config") {
+        val fileContents =
+          """eclipsestore {
+            |  backend {
+            |    nativeLocal {
+            |      snapshotPath = "/tmp/zio-eclipsestore-native-local.snapshot.pb"
+            |      serde = "protobuf"
+            |    }
+            |  }
+            |}
+            |""".stripMargin
+
+        for
+          path  <- tempConfigFile(fileContents)
+          env   <- EclipseStoreConfigZIO.backendFromFile(path).build
+          config = env.get[BackendConfig]
+        yield assertTrue(
+          config == BackendConfig.NativeLocal(
+            Path.of("/tmp/zio-eclipsestore-native-local.snapshot.pb"),
+            NativeLocalSerde.Protobuf,
+          )
+        )
+      },
     )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/config/EclipseStoreConfigZIOSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/config/EclipseStoreConfigZIOSpec.scala
@@ -1,11 +1,20 @@
 package io.github.riccardomerolla.zio.eclipsestore.config
 
-import java.nio.file.Path
+import java.nio.file.{ Files, Path }
 
 import zio.*
 import zio.test.*
 
 object EclipseStoreConfigZIOSpec extends ZIOSpecDefault:
+
+  private def tempConfigFile(contents: String): ZIO[Scope, Throwable, Path] =
+    ZIO.acquireRelease(
+      ZIO.attemptBlocking {
+        val path = Files.createTempFile("zio-eclipsestore-config", ".conf")
+        Files.writeString(path, contents)
+        path
+      }
+    )(path => ZIO.attemptBlocking(Files.deleteIfExists(path)).ignore)
 
   override def spec: Spec[Environment & (TestEnvironment & Scope), Any] =
     suite("EclipseStoreConfigZIO")(
@@ -31,5 +40,33 @@ object EclipseStoreConfigZIOSpec extends ZIOSpecDefault:
                         )
                       case _                              => ZIO.succeed(assertTrue(false))
         yield result
-      }
+      },
+      test("loads legacy backend selection from storageTarget config") {
+        for
+          env   <- EclipseStoreConfigZIO.backendFromResourcePath.build
+          config = env.get[BackendConfig]
+        yield assertTrue(config == BackendConfig.FileSystem(Path.of("/tmp/zio-eclipsestore-config-test")))
+      },
+      test("loads NativeLocal backend selection from backend config and prefers it over storageTarget") {
+        val fileContents =
+          """eclipsestore {
+            |  storageTarget {
+            |    fileSystem {
+            |      path = "/tmp/zio-eclipsestore-config-test"
+            |    }
+            |  }
+            |  backend {
+            |    nativeLocal {
+            |      snapshotPath = "/tmp/zio-eclipsestore-native-local.snapshot"
+            |    }
+            |  }
+            |}
+            |""".stripMargin
+
+        for
+          path  <- tempConfigFile(fileContents)
+          env   <- EclipseStoreConfigZIO.backendFromFile(path).build
+          config = env.get[BackendConfig]
+        yield assertTrue(config == BackendConfig.NativeLocal(Path.of("/tmp/zio-eclipsestore-native-local.snapshot")))
+      },
     )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala
@@ -7,6 +7,8 @@ import scala.jdk.CollectionConverters.*
 import zio.*
 import zio.test.*
 
+import io.github.riccardomerolla.zio.eclipsestore.config.NativeLocalSerde
+
 object TodoNativeLocalAppSpec extends ZIOSpecDefault:
 
   private def withTempDirectory[A](prefix: String)(use: Path => ZIO[Any, Throwable, A]): ZIO[Any, Throwable, A] =
@@ -41,5 +43,26 @@ object TodoNativeLocalAppSpec extends ZIOSpecDefault:
             reopened.exists(todo => todo.title == "record benchmark baseline" && !todo.completed),
           )).mapError(err => new RuntimeException(err.toString))
         }
-      }
+      },
+      test("persists protobuf todo mutations across checkpoint and restart") {
+        withTempDirectory("todo-native-local-protobuf-sample") { dir =>
+          val snapshotPath = dir.resolve("todo.snapshot.pb")
+          val layer        = TodoService.layer(snapshotPath, NativeLocalSerde.Protobuf)
+
+          (for
+            created  <- (for
+                          first <- TodoService.add("write protobuf docs")
+                          _     <- TodoService.add("verify protobuf sample")
+                          _     <- TodoService.complete(first.id)
+                          after <- TodoService.checkpointAndReload
+                        yield (first, after)).provideLayer(layer)
+            reopened <- TodoService.list.provideLayer(layer)
+          yield assertTrue(
+            created._2.size == 2,
+            reopened.size == 2,
+            reopened.exists(todo => todo.id == created._1.id && todo.completed),
+            reopened.exists(todo => todo.title == "verify protobuf sample" && !todo.completed),
+          )).mapError(err => new RuntimeException(err.toString))
+        }
+      },
     )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalAppSpec.scala
@@ -1,0 +1,45 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal
+
+import java.nio.file.{ Files, Path }
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.test.*
+
+object TodoNativeLocalAppSpec extends ZIOSpecDefault:
+
+  private def withTempDirectory[A](prefix: String)(use: Path => ZIO[Any, Throwable, A]): ZIO[Any, Throwable, A] =
+    ZIO.scoped {
+      ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory(prefix))) { path =>
+        ZIO.attemptBlocking {
+          if Files.exists(path) then
+            Files.walk(path).iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists)
+        }.ignore
+      }.flatMap(use)
+    }
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("TodoNativeLocalApp")(
+      test("persists todo mutations across checkpoint and restart") {
+        withTempDirectory("todo-native-local-sample") { dir =>
+          val snapshotPath = dir.resolve("todo.snapshot.json")
+          val layer        = TodoService.layer(snapshotPath)
+
+          (for
+            created  <- (for
+                          first <- TodoService.add("write docs")
+                          _     <- TodoService.add("record benchmark baseline")
+                          _     <- TodoService.complete(first.id)
+                          after <- TodoService.checkpointAndReload
+                        yield (first, after)).provideLayer(layer)
+            reopened <- TodoService.list.provideLayer(layer)
+          yield assertTrue(
+            created._2.size == 2,
+            reopened.size == 2,
+            reopened.exists(todo => todo.id == created._1.id && todo.completed),
+            reopened.exists(todo => todo.title == "record benchmark baseline" && !todo.completed),
+          )).mapError(err => new RuntimeException(err.toString))
+        }
+      }
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalEventSourcingSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalEventSourcingSpec.scala
@@ -1,0 +1,107 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal
+
+import java.nio.file.{ Files, Path }
+import java.util.UUID
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.NativeLocalSerde
+
+object TodoNativeLocalEventSourcingSpec extends ZIOSpecDefault:
+
+  private def withTempDirectory[A](prefix: String)(use: Path => ZIO[Any, Throwable, A]): ZIO[Any, Throwable, A] =
+    ZIO.scoped {
+      ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory(prefix))) { path =>
+        ZIO.attemptBlocking {
+          if Files.exists(path) then
+            Files.walk(path).iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists)
+        }.ignore
+      }.flatMap(use)
+    }
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("TodoNativeLocalEventSourcing")(
+      test("accepted commands append journal entries and keep the snapshot aligned with replay") {
+        withTempDirectory("todo-native-local-event-sourcing") { dir =>
+          val snapshotPath = dir.resolve("todo-event-sourcing.snapshot.json")
+          val layer        = TodoEventSourcedService.layer(snapshotPath)
+
+          (for
+            first    <- TodoEventSourcedService.add("map the article", "high")
+            _        <- TodoEventSourcedService.add("document the shell", "normal")
+            _        <- TodoEventSourcedService.complete(first.id)
+            journal  <- TodoEventSourcedService.journal
+            snapshot <- TodoEventSourcedService.currentState
+            replayed <- TodoEventSourcedService.replayedState
+          yield assertTrue(
+            journal.map(_.sequence) == Chunk(1L, 2L, 3L),
+            snapshot == replayed,
+            snapshot.items.size == 2,
+            snapshot.items.exists(todo => todo.id == first.id && todo.completed),
+            snapshot.items.exists(todo => todo.title == "document the shell" && !todo.completed),
+          )).provideLayer(layer).mapError(err => new RuntimeException(err.toString))
+        }
+      },
+      test("rejected commands keep the persisted journal and snapshot unchanged") {
+        withTempDirectory("todo-native-local-event-sourcing-failure") { dir =>
+          val snapshotPath = dir.resolve("todo-event-sourcing.snapshot.json")
+          val layer        = TodoEventSourcedService.layer(snapshotPath)
+          val missingId    = TodoId(UUID.randomUUID())
+
+          (for
+            created       <- TodoEventSourcedService.add("persist one todo", "low")
+            beforeJournal <- TodoEventSourcedService.journal
+            beforeState   <- TodoEventSourcedService.currentState
+            failure       <- TodoEventSourcedService.complete(missingId).either
+            afterJournal  <- TodoEventSourcedService.journal
+            afterState    <- TodoEventSourcedService.currentState
+          yield assertTrue(
+            created.title == "persist one todo",
+            failure.isLeft,
+            beforeJournal == afterJournal,
+            beforeState == afterState,
+            afterState.items.size == 1,
+            afterState.items.exists(todo => todo.id == created.id && !todo.completed),
+          )).provideLayer(layer).mapError(err => new RuntimeException(err.toString))
+        }
+      },
+      test("each accepted command is durable across a fresh reopen because the service checkpoints after processing") {
+        withTempDirectory("todo-native-local-event-sourcing-reopen") { dir =>
+          val snapshotPath = dir.resolve("todo-event-sourcing.snapshot.json")
+          val layer        = TodoEventSourcedService.layer(snapshotPath)
+
+          (for
+            first       <- (for
+                             first <- TodoEventSourcedService.add("persist the journal", "high")
+                             _     <- TodoEventSourcedService.complete(first.id)
+                           yield first).provideLayer(layer)
+            afterReopen <- TodoEventSourcedService.currentState.provideLayer(layer.fresh)
+            journal     <- TodoEventSourcedService.journal.provideLayer(layer.fresh)
+            replayed    <- TodoEventSourcedService.replayedState.provideLayer(layer.fresh)
+          yield assertTrue(
+            afterReopen == replayed,
+            journal.size == 2,
+            afterReopen.items.exists(todo => todo.id == first.id && todo.completed),
+          )).mapError(err => new RuntimeException(err.toString))
+        }
+      },
+      test("protobuf snapshots support the same event-sourced reopen flow") {
+        withTempDirectory("todo-native-local-event-sourcing-protobuf") { dir =>
+          val snapshotPath = dir.resolve("todo-event-sourcing.snapshot.pb")
+          val layer        = TodoEventSourcedService.layer(snapshotPath, NativeLocalSerde.Protobuf)
+
+          (for
+            _           <- TodoEventSourcedService.add("persist protobuf journal", "high").provideLayer(layer)
+            afterReopen <- TodoEventSourcedService.currentState.provideLayer(layer.fresh)
+            journal     <- TodoEventSourcedService.journal.provideLayer(layer.fresh)
+          yield assertTrue(
+            afterReopen.items.map(_.title) == Chunk("persist protobuf journal"),
+            journal.size == 1,
+            journal.map(_.sequence) == Chunk(1L),
+          )).mapError(err => new RuntimeException(err.toString))
+        }
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningSpec.scala
@@ -66,6 +66,45 @@ object TodoNativeLocalVersioningSpec extends ZIOSpecDefault:
       }).mapError(err => new RuntimeException(err.toString))
     }
 
+  private def autoVersioningScenario(
+    serde: NativeLocalSerde,
+    extension: String,
+  ): ZIO[Any, Throwable, TestResult] =
+    withTempDirectory(s"todo-auto-versioning-${extension.replace(".", "")}") { dir =>
+      val snapshotPath = dir.resolve(s"todo-auto-versioned$extension")
+      val v1Layer      = TodoV1Service.layer(snapshotPath, serde)
+      val autoV2Layer  = TodoV2Service.autoLayer(snapshotPath, serde)
+      val plainV2Layer = TodoV2Service.layer(snapshotPath, serde)
+
+      (for
+        seeded   <- (for
+                      first  <- TodoV1Service.add("auto migrate first", "docs")
+                      second <- TodoV1Service.add("auto migrate second", "ops")
+                      _      <- TodoV1Service.complete(first.id)
+                      _      <- TodoV1Service.checkpoint
+                    yield (first, second)).provideLayer(v1Layer)
+        migrated <- TodoV2Service.list.provideLayer(autoV2Layer)
+        after    <- (for
+                      createdV2 <- TodoV2Service.add("post-migration todo", "high")
+                      reopened  <- TodoV2Service.checkpointAndReload
+                    yield (createdV2, reopened)).provideLayer(autoV2Layer)
+        plain    <- TodoV2Service.list.provideLayer(plainV2Layer)
+      yield {
+        val createdV2 = after._1
+        val reopened  = after._2
+
+        assertTrue(
+          migrated.size == 2,
+          migrated.exists(todo => todo.id == seeded._1.id && todo.completed && todo.priority == "normal"),
+          migrated.exists(todo => todo.id == seeded._2.id && !todo.completed && todo.priority == "normal"),
+          reopened.size == 3,
+          reopened.exists(todo => todo.id == createdV2.id && todo.priority == "high" && !todo.completed),
+          plain.size == 3,
+          plain.exists(_.id == createdV2.id),
+        )
+      }).mapError(err => new RuntimeException(err.toString))
+    }
+
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("TodoNativeLocalVersioning")(
       test("manual JSON snapshot migration upgrades v1 todos to v2 and keeps writes working") {
@@ -73,5 +112,11 @@ object TodoNativeLocalVersioningSpec extends ZIOSpecDefault:
       },
       test("manual protobuf snapshot migration upgrades v1 todos to v2 and keeps writes working") {
         versioningScenario(NativeLocalSerde.Protobuf, ".pb")
+      },
+      test("auto JSON snapshot migration upgrades v1 todos on v2 startup and rewrites the snapshot") {
+        autoVersioningScenario(NativeLocalSerde.Json, ".json")
+      },
+      test("auto protobuf snapshot migration upgrades v1 todos on v2 startup and rewrites the snapshot") {
+        autoVersioningScenario(NativeLocalSerde.Protobuf, ".pb")
       },
     )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/examples/nativelocal/TodoNativeLocalVersioningSpec.scala
@@ -1,0 +1,77 @@
+package io.github.riccardomerolla.zio.eclipsestore.examples.nativelocal
+
+import java.nio.file.{ Files, Path }
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.NativeLocalSerde
+
+object TodoNativeLocalVersioningSpec extends ZIOSpecDefault:
+
+  private def withTempDirectory[A](prefix: String)(use: Path => ZIO[Any, Throwable, A]): ZIO[Any, Throwable, A] =
+    ZIO.scoped {
+      ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory(prefix))) { path =>
+        ZIO.attemptBlocking {
+          if Files.exists(path) then
+            Files.walk(path).iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists)
+        }.ignore
+      }.flatMap(use)
+    }
+
+  private def versioningScenario(
+    serde: NativeLocalSerde,
+    extension: String,
+  ): ZIO[Any, Throwable, TestResult] =
+    withTempDirectory(s"todo-versioning-${extension.replace(".", "")}") { dir =>
+      val snapshotPath = dir.resolve(s"todo-versioned$extension")
+      val v1Layer      = TodoV1Service.layer(snapshotPath, serde)
+      val v2Layer      = TodoV2Service.layer(snapshotPath, serde)
+
+      (for
+        seeded <- (for
+                    first  <- TodoV1Service.add("keep existing todos", "docs")
+                    second <- TodoV1Service.add("remove legacy field", "ops")
+                    _      <- TodoV1Service.complete(second.id)
+                    _      <- TodoV1Service.checkpoint
+                  yield (first, second)).provideLayer(v1Layer)
+        report <- TodoVersioning.migrateSnapshot(snapshotPath, serde)
+        after  <- (for
+                    migrated  <- TodoV2Service.list
+                    createdV2 <- TodoV2Service.add("new v2 todo", "high")
+                    reopened  <- TodoV2Service.checkpointAndReload
+                  yield (migrated, createdV2, reopened)).provideLayer(v2Layer)
+      yield {
+        val migrated     = after._1
+        val createdV2    = after._2
+        val reopened     = after._3
+        val oldCompleted =
+          reopened.find(_.id == seeded._2.id).exists(todo => todo.completed && todo.priority == "normal")
+        val oldPending   =
+          reopened.find(_.id == seeded._1.id).exists(todo => !todo.completed && todo.priority == "normal")
+        val newTodo      =
+          reopened.exists(todo => todo.id == createdV2.id && todo.priority == "high" && !todo.completed)
+
+        assertTrue(
+          report == TodoMigrationReport(TodoSchemaVersion.V1, TodoSchemaVersion.V2, migratedTodos = 2),
+          migrated.size == 2,
+          migrated.forall(_.priority == "normal"),
+          reopened.size == 3,
+          oldCompleted,
+          oldPending,
+          newTodo,
+        )
+      }).mapError(err => new RuntimeException(err.toString))
+    }
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("TodoNativeLocalVersioning")(
+      test("manual JSON snapshot migration upgrades v1 todos to v2 and keeps writes working") {
+        versioningScenario(NativeLocalSerde.Json, ".json")
+      },
+      test("manual protobuf snapshot migration upgrades v1 todos to v2 and keeps writes working") {
+        versioningScenario(NativeLocalSerde.Protobuf, ".pb")
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/schema/MigrationSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/schema/MigrationSpec.scala
@@ -1,0 +1,153 @@
+package io.github.riccardomerolla.zio.eclipsestore.schema
+
+import zio.*
+import zio.json.ast.Json
+import zio.schema.{ DeriveSchema, Schema }
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+
+object MigrationSpec extends ZIOSpecDefault:
+  final case class CustomerV1(id: String, name: String)
+  object CustomerV1:
+    given Schema[CustomerV1] = DeriveSchema.gen[CustomerV1]
+
+  final case class CustomerV2(id: String, name: String, active: Boolean)
+  object CustomerV2:
+    given Schema[CustomerV2] = DeriveSchema.gen[CustomerV2]
+
+  final case class ProfileV1(userId: String, fullName: String)
+  object ProfileV1:
+    given Schema[ProfileV1] = DeriveSchema.gen[ProfileV1]
+
+  final case class ProfileV2(userId: String, displayName: String)
+  object ProfileV2:
+    given Schema[ProfileV2] = DeriveSchema.gen[ProfileV2]
+
+  final case class AgeV1(age: String)
+  object AgeV1:
+    given Schema[AgeV1] = DeriveSchema.gen[AgeV1]
+
+  final case class AgeV2(age: Int)
+  object AgeV2:
+    given Schema[AgeV2] = DeriveSchema.gen[AgeV2]
+
+  final case class AccountV1(id: String, fullName: String)
+  object AccountV1:
+    given Schema[AccountV1] = DeriveSchema.gen[AccountV1]
+
+  final case class AccountV2(id: String, displayName: String)
+  object AccountV2:
+    given Schema[AccountV2] = DeriveSchema.gen[AccountV2]
+
+  final case class AccountV3(id: String, displayName: String, active: Boolean)
+  object AccountV3:
+    given Schema[AccountV3] = DeriveSchema.gen[AccountV3]
+
+  private val addDefaultPlan =
+    Migration
+      .define[CustomerV1, CustomerV2](
+        Migration.addField("active", Json.Bool(true))
+      )
+      .plan
+
+  private val renamePlan =
+    Migration
+      .define[ProfileV1, ProfileV2](
+        Migration.renameField("fullName", "displayName")
+      )
+      .plan
+
+  private val chainedPlan =
+    Migration
+      .define[AccountV1, AccountV2](
+        Migration.renameField("fullName", "displayName")
+      )
+      .andThen(
+        Migration.define[AccountV2, AccountV3](
+          Migration.addField("active", Json.Bool(true))
+        )
+      )
+      .plan
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("Migration")(
+      test("adds a default value when a field is introduced") {
+        val input = CustomerV1("cust-1", "Ada")
+
+        for
+          _      <- addDefaultPlan.validate
+          output <- addDefaultPlan.migrate(input)
+        yield assertTrue(
+          output == CustomerV2("cust-1", "Ada", active = true)
+        )
+      },
+      test("renames fields without losing values") {
+        val input = ProfileV1("user-1", "Ada Lovelace")
+
+        for
+          _      <- renamePlan.validate
+          output <- renamePlan.migrate(input)
+        yield assertTrue(
+          output == ProfileV2("user-1", "Ada Lovelace")
+        )
+      },
+      test("fails validation when a field type changes without a converter") {
+        val plan = Migration.define[AgeV1, AgeV2]().plan
+
+        for
+          failure <- plan.validate.flip
+        yield assertTrue(
+          failure match
+            case EclipseStoreError.IncompatibleSchemaError(message, _) =>
+              message.contains("changed type without a converter")
+            case _                                                     => false
+        )
+      },
+      test("composes chained migrations across multiple schema versions") {
+        val input = AccountV1("acct-1", "Grace Hopper")
+
+        for
+          _      <- chainedPlan.validate
+          output <- chainedPlan.migrate(input)
+        yield assertTrue(
+          output == AccountV3("acct-1", "Grace Hopper", active = true)
+        )
+      },
+      test("compatible upgrades load existing payloads without explicit reserialization") {
+        val payloads =
+          Chunk.fromIterable((1 to 256).map(index => CustomerV1(s"cust-$index", s"Customer $index")))
+
+        for
+          _        <- addDefaultPlan.validate
+          upgraded <- ZIO.foreach(payloads)(addDefaultPlan.migrate)
+        yield assertTrue(
+          upgraded.size == payloads.size,
+          upgraded.forall(_.active),
+          upgraded.headOption.contains(CustomerV2("cust-1", "Customer 1", active = true)),
+        )
+      },
+      test("validated converters preserve semantics across generated values") {
+        val plan =
+          Migration
+            .define[AgeV1, AgeV2](
+              Migration.changeField("age")(jsonValue =>
+                jsonValue match
+                  case Json.Str(value) =>
+                    ZIO
+                      .attempt(value.toInt)
+                      .mapBoth(
+                        cause => EclipseStoreError.MigrationError("Age converter must parse integers", Some(cause)),
+                        number => Json.Num(number),
+                      )
+                  case other           =>
+                    ZIO.fail(EclipseStoreError.MigrationError(s"Expected string age payload, found $other", None))
+              )
+            )
+            .plan
+
+        check(Gen.int(0, 120)) { age =>
+          plan.validate *> plan.migrate(AgeV1(age.toString)).map(output => assertTrue(output.age == age))
+        }
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/schema/SchemaSerializerSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/schema/SchemaSerializerSpec.scala
@@ -1,0 +1,170 @@
+package io.github.riccardomerolla.zio.eclipsestore.schema
+
+import java.nio.file.Files
+import java.time.Instant
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.schema.{ Schema, StandardType, derived }
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.{ EclipseStoreConfig, StorageTarget }
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+
+object SchemaSerializerSpec extends ZIOSpecDefault:
+  opaque type UserId = String
+
+  object UserId:
+    def apply(value: String): UserId = value
+
+    extension (userId: UserId) def value: String = userId
+
+  given Schema[UserId] =
+    Schema.primitive(StandardType.StringType).asInstanceOf[Schema[UserId]]
+
+  enum DeliveryState derives Schema:
+    case Pending
+    case Delivered(at: Instant)
+
+  final case class Shipment(
+    id: UserId,
+    aliases: Chunk[String],
+    primaryContact: Either[String, Int],
+    state: DeliveryState,
+  ) derives Schema
+
+  final case class RecursiveNode(
+    id: String,
+    children: List[RecursiveNode],
+  ) derives Schema
+
+  final case class TrackedIssue(
+    id: String,
+    state: IssueState,
+    severity: IssueSeverity,
+    summary: String,
+  ) derives Schema
+
+  private val serializer = SchemaSerializerLive()
+
+  private def tempDirectory(prefix: String): ZIO[Scope, EclipseStoreError, java.nio.file.Path] =
+    ZIO.acquireRelease(
+      ZIO
+        .attempt(Files.createTempDirectory(prefix))
+        .mapError(cause =>
+          EclipseStoreError.InitializationError(s"Failed to create $prefix temp directory", Some(cause))
+        )
+    )(path =>
+      ZIO.attempt {
+        if Files.exists(path) then
+          Files.walk(path).iterator().asScala.toList.reverse.foreach(Files.deleteIfExists)
+      }.orDie
+    )
+
+  private def restartRoundTrip(
+    config: EclipseStoreConfig,
+    write: EclipseStoreService => IO[EclipseStoreError, Unit],
+    read: EclipseStoreService => IO[EclipseStoreError, TrackedIssue],
+  ): ZIO[Any, EclipseStoreError, TrackedIssue] =
+    val layer = ZLayer.succeed(config) >>> EclipseStoreService.live
+    for
+      _   <- ZIO.scoped {
+               for
+                 writerEnv <- layer.build
+                 writer     = writerEnv.get[EclipseStoreService]
+                 _         <- write(writer)
+               yield ()
+             }
+      out <- ZIO.scoped {
+               for
+                 readerEnv <- layer.build
+                 reader     = readerEnv.get[EclipseStoreService]
+                 value     <- read(reader)
+               yield value
+             }
+    yield out
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("SchemaSerializer")(
+      test("encodes and decodes schema-driven values without leaking Java serialization") {
+        val shipment = Shipment(
+          id = UserId("user-1"),
+          aliases = Chunk("ops", "priority"),
+          primaryContact = Right(42),
+          state = DeliveryState.Delivered(Instant.ofEpochMilli(1_723_456_789_123L)),
+        )
+
+        for
+          encoded <- serializer.encode(shipment)
+          decoded <- serializer.decode[Shipment](encoded)
+        yield assertTrue(
+          encoded.contains("user-1"),
+          encoded.contains("priority"),
+          decoded == shipment,
+        )
+      },
+      test("round-trips recursive values and opaque wrappers through the schema boundary") {
+        val root = RecursiveNode(
+          id = "root",
+          children = List(
+            RecursiveNode("left", Nil),
+            RecursiveNode("right", List(RecursiveNode("right-leaf", Nil))),
+          ),
+        )
+
+        for
+          encoded <- serializer.encode(root)
+          decoded <- serializer.decode[RecursiveNode](encoded)
+        yield assertTrue(
+          encoded.contains("right-leaf"),
+          decoded == root,
+        )
+      },
+      test("derives stable handlers and deduplicated config registration from Schema[A]") {
+        val config = EclipseStoreConfig(StorageTarget.InMemory("schema-serializer-registration"))
+
+        for
+          firstHandler  <- serializer.typeHandler[Shipment]
+          secondHandler <- serializer.typeHandler[Shipment]
+          registered    <- serializer.register[Shipment](config)
+          registered2   <- serializer.register[Shipment](registered)
+          runtimeTypes   = registered2.customTypeHandlers.map(_.`type`()).toSet
+        yield assertTrue(
+          firstHandler.typeId == secondHandler.typeId,
+          firstHandler.runtimeClass == secondHandler.runtimeClass,
+          runtimeTypes.contains(firstHandler.runtimeClass),
+          registered.customTypeHandlers.nonEmpty,
+          registered2.customTypeHandlers.size == runtimeTypes.size,
+        )
+      },
+      test("registered schema handlers preserve enum pattern matching after restart") {
+        val issue = TrackedIssue(
+          id = "issue-1",
+          state = IssueState.Closed(reason = Some("resolved")),
+          severity = IssueSeverity.High(),
+          summary = "SchemaSerializer registration path",
+        )
+
+        for
+          dir    <- tempDirectory("schema-serializer-restart")
+          config <- serializer.register[TrackedIssue](
+                      EclipseStoreConfig(storageTarget = StorageTarget.FileSystem(dir))
+                    )
+          out    <- restartRoundTrip(
+                      config = config,
+                      write = svc => svc.put("issue", issue),
+                      read = svc =>
+                        svc
+                          .get[String, TrackedIssue]("issue")
+                          .someOrFail(EclipseStoreError.QueryError("Missing issue after restart", None)),
+                    )
+        yield assertTrue(
+          out == issue,
+          out.state match
+            case IssueState.Closed(Some("resolved")) => true
+            case _                                   => false,
+        )
+      },
+    )

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistenceSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistenceSpec.scala
@@ -30,10 +30,11 @@ object StreamingPersistenceSpec extends ZIOSpecDefault:
     inMemoryTypedStore ++ (inMemoryTypedStore >>> StreamingPersistence.live(descriptor))
 
   @annotation.nowarn("cat=deprecation")
-  private def persistentLayer(path: Path): ZLayer[Any, EclipseStoreError, StreamingPersistence[StreamRoot] & TypedStore] =
+  private def persistentLayer(path: Path)
+    : ZLayer[Any, EclipseStoreError, StreamingPersistence[StreamRoot] & TypedStore] =
     val typedStoreLayer =
       ZLayer.succeed(
-      EclipseStoreConfig(storageTarget = StorageTarget.FileSystem(path))
+        EclipseStoreConfig(storageTarget = StorageTarget.FileSystem(path))
       ) >>>
         TypedStore.handlersFor[String, Event] >>>
         EclipseStoreService.live >>>
@@ -117,47 +118,48 @@ object StreamingPersistenceSpec extends ZIOSpecDefault:
           dir <- tempDirectory("streaming-interrupt")
           out <- ZIO.scoped {
                    for {
-                     env <- persistentLayer(dir).build
-                     fiber <- StreamingPersistence
-                       .ingest[StreamRoot, String, Event](
-                         delayedInput,
-                         IngestionConfig(batchSize = 8, parallelism = 1, errorStrategy = ErrorStrategy.FailFast),
-                       )
-                       .provideEnvironment(env)
-                       .fork
-                     _ <- Live.live(ZIO.sleep(150.millis))
-                     _ <- fiber.interrupt
+                     env    <- persistentLayer(dir).build
+                     fiber  <-
+                       StreamingPersistence
+                         .ingest[StreamRoot, String, Event](
+                           delayedInput,
+                           IngestionConfig(batchSize = 8, parallelism = 1, errorStrategy = ErrorStrategy.FailFast),
+                         )
+                         .provideEnvironment(env)
+                         .fork
+                     _      <- Live.live(ZIO.sleep(150.millis))
+                     _      <- fiber.interrupt
                      values <- TypedStore.fetchAll[Event].provideEnvironment(env)
                    } yield values
                  }
         yield assertTrue(out.nonEmpty, out.size < 120)
       },
       test("parallel ingestion from multiple fibers does not lose records") {
-        val first =
+        val first  =
           ZStream.fromIterable(1 to 200).map(index => IngestionItem.Record(s"a:$index", event(index)))
         val second =
           ZStream.fromIterable(201 to 400).map(index => IngestionItem.Record(s"b:$index", event(index)))
 
         ZIO.scoped {
           for
-            env      <- inMemoryLayer.build
-            reportA  <- StreamingPersistence
-                          .ingest[StreamRoot, String, Event](
-                            first,
-                            IngestionConfig(batchSize = 32, parallelism = 2, errorStrategy = ErrorStrategy.FailFast),
-                          )
-                          .provideEnvironment(env)
-                          .fork
-            reportB  <- StreamingPersistence
-                          .ingest[StreamRoot, String, Event](
-                            second,
-                            IngestionConfig(batchSize = 32, parallelism = 2, errorStrategy = ErrorStrategy.FailFast),
-                          )
-                          .provideEnvironment(env)
-                          .fork
-            doneA    <- reportA.join
-            doneB    <- reportB.join
-            values   <- TypedStore.fetchAll[Event].provideEnvironment(env)
+            env     <- inMemoryLayer.build
+            reportA <- StreamingPersistence
+                         .ingest[StreamRoot, String, Event](
+                           first,
+                           IngestionConfig(batchSize = 32, parallelism = 2, errorStrategy = ErrorStrategy.FailFast),
+                         )
+                         .provideEnvironment(env)
+                         .fork
+            reportB <- StreamingPersistence
+                         .ingest[StreamRoot, String, Event](
+                           second,
+                           IngestionConfig(batchSize = 32, parallelism = 2, errorStrategy = ErrorStrategy.FailFast),
+                         )
+                         .provideEnvironment(env)
+                         .fork
+            doneA   <- reportA.join
+            doneB   <- reportB.join
+            values  <- TypedStore.fetchAll[Event].provideEnvironment(env)
           yield assertTrue(
             doneA.committed == 200,
             doneB.committed == 200,
@@ -191,10 +193,11 @@ object StreamingPersistenceSpec extends ZIOSpecDefault:
 
           (
             for
-              report  <- StreamingPersistence.ingest[StreamRoot, String, Event](
-                           input,
-                           IngestionConfig(batchSize = batchSize, parallelism = 1, errorStrategy = ErrorStrategy.FailFast),
-                         )
+              report  <-
+                StreamingPersistence.ingest[StreamRoot, String, Event](
+                  input,
+                  IngestionConfig(batchSize = batchSize, parallelism = 1, errorStrategy = ErrorStrategy.FailFast),
+                )
               batches <- StreamingPersistence
                            .extractBatches[StreamRoot, Event](_ => true, batchSize)
                            .runCollect

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistenceSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistenceSpec.scala
@@ -64,6 +64,15 @@ object StreamingPersistenceSpec extends ZIOSpecDefault:
       createdAt = Instant.ofEpochMilli(index.toLong),
     )
 
+  private def waitForCommitted(env: ZEnvironment[StreamingPersistence[StreamRoot] & TypedStore])
+    : IO[EclipseStoreError, Unit] =
+    TypedStore.fetchAll[Event].provideEnvironment(env).flatMap { values =>
+      if values.nonEmpty then ZIO.unit
+      else
+        Live.live(ZIO.sleep(10.millis)) *>
+          waitForCommitted(env)
+    }
+
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("StreamingPersistence")(
       test("large ingestion completes with batching and reaches eventual consistency") {
@@ -127,7 +136,9 @@ object StreamingPersistenceSpec extends ZIOSpecDefault:
                          )
                          .provideEnvironment(env)
                          .fork
-                     _      <- Live.live(ZIO.sleep(150.millis))
+                     _      <- waitForCommitted(env).timeoutFail(
+                                 EclipseStoreError.QueryError("Timed out waiting for committed streaming records", None)
+                               )(1.second)
                      _      <- fiber.interrupt
                      values <- TypedStore.fetchAll[Event].provideEnvironment(env)
                    } yield values

--- a/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistenceSpec.scala
+++ b/src/test/scala/io/github/riccardomerolla/zio/eclipsestore/schema/StreamingPersistenceSpec.scala
@@ -1,0 +1,212 @@
+package io.github.riccardomerolla.zio.eclipsestore.schema
+
+import java.nio.file.{ Files, Path }
+import java.time.Instant
+
+import scala.jdk.CollectionConverters.*
+
+import zio.*
+import zio.schema.{ Schema, derived }
+import zio.stream.ZStream
+import zio.test.*
+
+import io.github.riccardomerolla.zio.eclipsestore.config.{ EclipseStoreConfig, StorageTarget }
+import io.github.riccardomerolla.zio.eclipsestore.domain.RootDescriptor
+import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
+import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+
+object StreamingPersistenceSpec extends ZIOSpecDefault:
+  final case class StreamRoot(version: Int) derives Schema
+  final case class Event(id: String, partition: Int, payload: String, createdAt: Instant) derives Schema
+
+  private val descriptor =
+    RootDescriptor.fromSchema[StreamRoot]("stream-root", () => StreamRoot(0))
+
+  @annotation.nowarn("cat=deprecation")
+  private val inMemoryTypedStore: ULayer[TypedStore] =
+    EclipseStoreService.inMemory >>> TypedStore.live
+
+  private val inMemoryLayer: ULayer[StreamingPersistence[StreamRoot] & TypedStore] =
+    inMemoryTypedStore ++ (inMemoryTypedStore >>> StreamingPersistence.live(descriptor))
+
+  @annotation.nowarn("cat=deprecation")
+  private def persistentLayer(path: Path): ZLayer[Any, EclipseStoreError, StreamingPersistence[StreamRoot] & TypedStore] =
+    val typedStoreLayer =
+      ZLayer.succeed(
+      EclipseStoreConfig(storageTarget = StorageTarget.FileSystem(path))
+      ) >>>
+        TypedStore.handlersFor[String, Event] >>>
+        EclipseStoreService.live >>>
+        TypedStore.live
+
+    typedStoreLayer ++ (typedStoreLayer >>> StreamingPersistence.live(descriptor))
+
+  private def tempDirectory(prefix: String): ZIO[Scope, EclipseStoreError, Path] =
+    ZIO.acquireRelease(
+      ZIO
+        .attempt(Files.createTempDirectory(prefix))
+        .mapError(cause =>
+          EclipseStoreError.InitializationError(s"Failed to create $prefix temp directory", Some(cause))
+        )
+    )(path =>
+      ZIO.attempt {
+        if Files.exists(path) then
+          Files.walk(path).iterator().asScala.toList.reverse.foreach(Files.deleteIfExists)
+      }.orDie
+    )
+
+  private def event(index: Int): Event =
+    Event(
+      id = s"evt-$index",
+      partition = index % 8,
+      payload = s"payload-$index",
+      createdAt = Instant.ofEpochMilli(index.toLong),
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("StreamingPersistence")(
+      test("large ingestion completes with batching and reaches eventual consistency") {
+        val count = 2048
+        val input = ZStream.fromIterable(1 to count).map(index => IngestionItem.Record(s"event:$index", event(index)))
+
+        for
+          report <- StreamingPersistence.ingest[StreamRoot, String, Event](
+                      input,
+                      IngestionConfig(batchSize = 64, parallelism = 4, errorStrategy = ErrorStrategy.FailFast),
+                    )
+          all    <- TypedStore.fetchAll[Event]
+        yield assertTrue(
+          report.committed == count,
+          report.parked.isEmpty,
+          all.size == count,
+        )
+      }.provideLayer(inMemoryLayer),
+      test("park strategy routes malformed records aside without stopping ingestion") {
+        val input = ZStream.fromIterable(
+          Chunk(
+            IngestionItem.Record("event:1", event(1)),
+            IngestionItem.Malformed(
+              """{"id":"broken"}""",
+              EclipseStoreError.QueryError("Malformed event payload", None),
+            ),
+            IngestionItem.Record("event:2", event(2)),
+          )
+        )
+
+        for
+          report <- StreamingPersistence.ingest[StreamRoot, String, Event](
+                      input,
+                      IngestionConfig(batchSize = 2, parallelism = 1, errorStrategy = ErrorStrategy.Park),
+                    )
+          all    <- TypedStore.fetchAll[Event]
+        yield assertTrue(
+          report.committed == 2,
+          report.parked.size == 1,
+          all.map(_.id).toSet == Set("evt-1", "evt-2"),
+        )
+      }.provideLayer(inMemoryLayer),
+      test("interruption keeps already committed records durable") {
+        val delayedInput =
+          ZStream
+            .fromIterable(1 to 120)
+            .mapZIO(index =>
+              Live.live(ZIO.sleep(5.millis)).as(IngestionItem.Record(s"event:$index", event(index)))
+            )
+
+        for
+          dir <- tempDirectory("streaming-interrupt")
+          out <- ZIO.scoped {
+                   for {
+                     env <- persistentLayer(dir).build
+                     fiber <- StreamingPersistence
+                       .ingest[StreamRoot, String, Event](
+                         delayedInput,
+                         IngestionConfig(batchSize = 8, parallelism = 1, errorStrategy = ErrorStrategy.FailFast),
+                       )
+                       .provideEnvironment(env)
+                       .fork
+                     _ <- Live.live(ZIO.sleep(150.millis))
+                     _ <- fiber.interrupt
+                     values <- TypedStore.fetchAll[Event].provideEnvironment(env)
+                   } yield values
+                 }
+        yield assertTrue(out.nonEmpty, out.size < 120)
+      },
+      test("parallel ingestion from multiple fibers does not lose records") {
+        val first =
+          ZStream.fromIterable(1 to 200).map(index => IngestionItem.Record(s"a:$index", event(index)))
+        val second =
+          ZStream.fromIterable(201 to 400).map(index => IngestionItem.Record(s"b:$index", event(index)))
+
+        ZIO.scoped {
+          for
+            env      <- inMemoryLayer.build
+            reportA  <- StreamingPersistence
+                          .ingest[StreamRoot, String, Event](
+                            first,
+                            IngestionConfig(batchSize = 32, parallelism = 2, errorStrategy = ErrorStrategy.FailFast),
+                          )
+                          .provideEnvironment(env)
+                          .fork
+            reportB  <- StreamingPersistence
+                          .ingest[StreamRoot, String, Event](
+                            second,
+                            IngestionConfig(batchSize = 32, parallelism = 2, errorStrategy = ErrorStrategy.FailFast),
+                          )
+                          .provideEnvironment(env)
+                          .fork
+            doneA    <- reportA.join
+            doneB    <- reportB.join
+            values   <- TypedStore.fetchAll[Event].provideEnvironment(env)
+          yield assertTrue(
+            doneA.committed == 200,
+            doneB.committed == 200,
+            values.size == 400,
+            values.map(_.id).toSet.size == 400,
+          )
+        }
+      },
+      test("filtered extraction streams bounded batches") {
+        val input = ZStream.fromIterable(1 to 150).map(index => IngestionItem.Record(s"event:$index", event(index)))
+
+        for
+          _       <- StreamingPersistence.ingest[StreamRoot, String, Event](
+                       input,
+                       IngestionConfig(batchSize = 25, parallelism = 2, errorStrategy = ErrorStrategy.FailFast),
+                     )
+          batches <- StreamingPersistence
+                       .extractBatches[StreamRoot, Event](_.partition == 0, batchSize = 11)
+                       .runCollect
+        yield
+          val flattened = batches.flatten
+          assertTrue(
+            batches.forall(_.size <= 11),
+            flattened.forall(_.partition == 0),
+            flattened.nonEmpty,
+          )
+      }.provideLayer(inMemoryLayer),
+      test("batch extraction does not drop elements or exceed configured limits") {
+        check(Gen.int(1, 60), Gen.int(1, 12)) { (size, batchSize) =>
+          val input = ZStream.fromIterable(1 to size).map(index => IngestionItem.Record(s"event:$index", event(index)))
+
+          (
+            for
+              report  <- StreamingPersistence.ingest[StreamRoot, String, Event](
+                           input,
+                           IngestionConfig(batchSize = batchSize, parallelism = 1, errorStrategy = ErrorStrategy.FailFast),
+                         )
+              batches <- StreamingPersistence
+                           .extractBatches[StreamRoot, Event](_ => true, batchSize)
+                           .runCollect
+            yield
+              val flattened = batches.flatten
+              assertTrue(
+                report.committed == size,
+                batches.forall(_.size <= batchSize),
+                flattened.size == size,
+                flattened.map(_.id).toSet.size == size,
+              )
+          ).provideLayer(inMemoryLayer)
+        }
+      },
+    )

--- a/storage-sqlite/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/sqlite/SQLiteAdapter.scala
+++ b/storage-sqlite/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/sqlite/SQLiteAdapter.scala
@@ -4,9 +4,9 @@ import java.nio.file.Path
 
 import zio.*
 
-import io.github.riccardomerolla.zio.eclipsestore.config.{ EclipseStoreConfig, StorageTarget }
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, EclipseStoreConfig, StorageTarget }
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
-import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, StorageBackend }
 
 /** Convenience wiring for EclipseStore backed by a SQLite storage target. */
 object SQLiteAdapter:
@@ -27,7 +27,7 @@ object SQLiteAdapter:
     storageName: String = "eclipsestore.db",
     connectionString: Option[String] = None,
   ): ZLayer[Any, EclipseStoreError, EclipseStoreService] =
-    ZLayer.succeed(config(basePath, storageName, connectionString)) >>> EclipseStoreService.live
+    ZLayer.succeed(BackendConfig.Sqlite(basePath.resolve(storageName), storageName, connectionString)) >>> StorageBackend.service()
 
   /** Accessor layer if config already provided. */
   val service: ZLayer[EclipseStoreConfig, EclipseStoreError, EclipseStoreService] =

--- a/storage-sqlite/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/sqlite/SQLiteStorage.scala
+++ b/storage-sqlite/src/main/scala/io/github/riccardomerolla/zio/eclipsestore/sqlite/SQLiteStorage.scala
@@ -4,9 +4,9 @@ import java.nio.file.Path
 
 import zio.*
 
-import io.github.riccardomerolla.zio.eclipsestore.config.{ EclipseStoreConfig, StorageTarget }
+import io.github.riccardomerolla.zio.eclipsestore.config.{ BackendConfig, EclipseStoreConfig, StorageTarget }
 import io.github.riccardomerolla.zio.eclipsestore.error.EclipseStoreError
-import io.github.riccardomerolla.zio.eclipsestore.service.EclipseStoreService
+import io.github.riccardomerolla.zio.eclipsestore.service.{ EclipseStoreService, StorageBackend }
 
 /** ZIO-friendly wiring helpers for SQLite storage targets. */
 object SQLiteStorage:
@@ -25,7 +25,7 @@ object SQLiteStorage:
     storageName: String = "eclipsestore.db",
     connectionString: Option[String] = None,
   ): ZLayer[Any, EclipseStoreError, EclipseStoreService] =
-    ZLayer.succeed(config(path, storageName, connectionString)) >>> EclipseStoreService.live
+    ZLayer.succeed(BackendConfig.Sqlite(path.resolve(storageName), storageName, connectionString)) >>> StorageBackend.service()
 
   /** Convenience accessor to use an existing config layer (e.g., from test setup). */
   val service: ZLayer[EclipseStoreConfig, EclipseStoreError, EclipseStoreService] =


### PR DESCRIPTION
Introduce the Scala-native API contract, typed ObjectStore facade, schema-native serialization, layer-based storage backends, ZIO-native lazy references, and storage locking mechanisms. Implement a schema migration DSL, advanced GigaMap indexing, and a streaming persistence layer. Enhance observability with typed wrappers and provide a persistence testkit. Include sample applications and documentation to demonstrate the engine's capabilities.



Fixes #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47